### PR TITLE
Prep portfolio for senior UX engineering application

### DIFF
--- a/content/case-studies/ai-tooling.md
+++ b/content/case-studies/ai-tooling.md
@@ -1,0 +1,122 @@
+# AI Toolchain — Intake
+
+Page: `src/app/work/ai-tooling/page.tsx`
+Status: scaffolded, awaiting content
+
+Fill these in (any depth). I'll polish + wire into the page.
+
+This case study is your direct match for the JD line: *"a forward thinker — you track where AI-powered design tooling is heading, not just what it can do today, and you position your work on that slope."* Lean into that voice.
+
+---
+
+## OVERVIEW
+
+### timeline
+e.g. "ongoing since {month}, 2025"
+
+→ ANSWER:
+
+### roles — adopted by
+The page lists "design system implementation team, data migration team" — any other teams using the toolchain?
+
+→ OTHER TEAMS:
+
+### tools & methods
+The page lists Claude Code, MCP, Python, TypeScript. Anything else (Cursor? Code Sandbox? specific MCP servers)?
+
+→ OTHER TOOLS:
+
+### the bet (1-line + 2-4 sentences)
+The 1-line is your thesis — why invest in AI tooling now. The paragraph is the slope you're tracking, why generic AI assistants weren't enough, and what "code-ready output" means to you.
+
+→ 1-line thesis:
+
+→ 2-4 sentences:
+
+### outcome (with at least one number)
+Adoption rate, time saved, what kinds of work shifted from manual to automated. Resume mentions "60% turnaround reduction across 12+ projects" — does that apply here?
+
+→ ANSWER:
+
+---
+
+## ORIGIN
+
+### the gap
+What was happening before? Engineers re-writing similar boilerplate, design tokens not surfacing in code suggestions, manual translation between Figma and components, etc.
+
+→ ANSWER:
+
+### design principle: code-ready output
+The principle that drove the design — the bar isn't "plausible suggestion," it's "paste-able into prod." How did you operationalize that into prompts, skill scopes, MCP server contracts?
+
+→ ANSWER:
+
+---
+
+## THE TOOLKIT
+
+### skills — keystone examples (1-2)
+Walk through 1-2 keystone Claude Code skills. What they do, how they're scoped, what code-ready output they produce. (e.g. "design-token-emit", "component-from-figma".)
+
+→ SKILL 1 — name + what it does + example output:
+
+→ SKILL 2 (optional):
+
+### agents (1-2)
+Agents you built. Their job, their tools, what success looks like for each.
+
+→ AGENT 1:
+
+→ AGENT 2 (optional):
+
+### mcp workflows
+Which MCP servers did you stand up or integrate? What did the integration unlock?
+
+→ ANSWER:
+
+---
+
+## TEAM ADOPTION
+
+### how it spread
+How the toolchain went from your laptop to team standard. Onboarding, internal docs, the team-first design choices.
+
+→ ANSWER:
+
+### impact
+Numbers + stories. Concrete examples of work that got faster or higher-quality. Anything that's now possible that wasn't before.
+
+→ ANSWER:
+
+---
+
+## IMPLEMENTATION
+
+### how it works under the hood
+Technical detail for an engineering reader. Skill anatomy, agent tool wiring, MCP server contracts. One or two real prompts/configs if shareable.
+
+→ ANSWER:
+
+### where this goes next
+The slope. Where AI-powered design tooling is heading, and where this toolchain is positioned on it. (Also good cover-letter material.)
+
+→ ANSWER:
+
+---
+
+## SCREENSHOTS
+
+Drop into: `public/case-studies/ai-tooling/`
+
+Suggested filenames:
+
+- [ ] `hero.png` — opening visual (terminal screenshot? skill output diff? agent action?)
+- [ ] `skill-demo.png` — a skill in action with code-ready output
+
+Other useful:
+
+- [ ] `agent-flow.png` — agent decision/tool flow
+- [ ] `mcp-architecture.png` — MCP server architecture diagram
+- [ ] `before-after.png` — manual workflow vs. agent-driven workflow
+- [ ] anything that visualizes "code-ready output"

--- a/content/case-studies/design-system.md
+++ b/content/case-studies/design-system.md
@@ -1,7 +1,9 @@
-# Design System — Intake
+# Site-wide UI Refresh — Intake
 
 Page: `src/app/work/design-system/page.tsx`
 Status: scaffolded, awaiting content
+
+This case study covers the **site-wide UI refresh** — the project that produced the design system, not a specific feature. The refresh was unveiled at the annual user conference; the design system is the artifact that made it possible.
 
 Fill these in (any depth — sentences or bullets, doesn't matter). I'll polish + wire into the page.
 
@@ -10,7 +12,7 @@ Fill these in (any depth — sentences or bullets, doesn't matter). I'll polish 
 ## OVERVIEW
 
 ### timeline
-e.g. "~12 months, June 2024 – present"
+e.g. "~12 months, June 2024 – {month} 2025, unveiled at the {year} annual user conference"
 
 → ANSWER:
 
@@ -20,14 +22,14 @@ The page asks: "Style Dictionary? hand-sync? Figma variables → Tailwind config
 → ANSWER (be honest — this is a JD "plus" item; we want to claim only what's true):
 
 ### the problem (1-line + 2-4 sentences)
-What was fragmented before? What did one-off UI cost the org? Why did this need to exist?
+The product needed a refresh, but the org had no system to refresh it *on*. Frame the problem as "why the refresh and the system had to ship together."
 
 → 1-line:
 
-→ 2-4 sentences:
+→ 2-4 sentences (years of UI debt, fragmented patterns, why piecemeal wouldn't scale):
 
 ### outcome (with at least one number)
-What shipped? Adoption %, components count, regressions avoided, time-to-ship reduction.
+The refresh was unveiled at the annual user conference. Lead with what shipped: surfaces refreshed, components in production, regressions avoided, adoption.
 
 → ANSWER:
 
@@ -36,7 +38,7 @@ What shipped? Adoption %, components count, regressions avoided, time-to-ship re
 ## DESIGN PROCESS
 
 ### research — discovery
-How did you map the existing UI surface area? Audit of inconsistencies. Talking to engineers about what they kept rebuilding.
+How did you map the existing UI surface area before the refresh? Audit of inconsistencies. Talking to engineers about what they kept rebuilding.
 
 → ANSWER:
 
@@ -46,12 +48,12 @@ Which design systems did you study (Polaris, Carbon, Material, etc.)? What did y
 → ANSWER:
 
 ### ui audit — framing
-1-2 sentences on what you found across the legacy ASP.NET surface.
+1-2 sentences on what the audit found across the legacy ASP.NET surface — what was driving the need for the refresh.
 
 → ANSWER:
 
 ### ui audit — insight #1 (heading + 2-3 sentences)
-e.g. "inconsistent spacing"
+e.g. "inconsistent spacing across surfaces"
 
 → HEADING:
 → 2-3 SENTENCES:
@@ -70,12 +72,12 @@ The token layers — primitive → semantic → component. Where the source of t
 ## THE SYSTEM
 
 ### components
-Walk through the keystone components. Show variants, states, and the decisions behind them.
+The keystone components that powered the refresh. Variants, states, decisions behind them.
 
 → ANSWER:
 
 ### documented states & a11y
-How you documented interaction states + WCAG. (This is the "state modeling, demonstrated in shipped work" requirement — important.)
+How you documented interaction states + WCAG. (This is the JD's "state modeling, demonstrated in shipped work" requirement — important.)
 
 → ANSWER:
 
@@ -84,13 +86,13 @@ How you documented interaction states + WCAG. (This is the "state modeling, demo
 ## SYSTEM CONTRIBUTION
 
 ### from one-off to reusable
-1-2 concrete examples of feature work that you abstracted into reusable system primitives. Where else are they used now?
+1-2 concrete examples where one-off UI work during the refresh got abstracted into reusable system primitives. Where else are they used now?
 
 → EXAMPLE 1:
 → EXAMPLE 2:
 
 ### adoption
-How the system spread. Which teams adopted first, the contribution model, how you kept it the easy + right path.
+How the system spread beyond the refresh itself. Which teams adopted first, the contribution model, how you kept it the easy + right path.
 
 → ANSWER:
 
@@ -99,7 +101,7 @@ How the system spread. Which teams adopted first, the contribution model, how yo
 ## IMPLEMENTATION
 
 ### design intent → production code
-The legacy ASP.NET / DevExpress shipping story. Backwards-compatible CSS / JS / C#. How the system landed without regressions.
+The legacy ASP.NET / DevExpress shipping story. Backwards-compatible CSS / JS / C#. How the refresh landed without regressions.
 
 → ANSWER:
 
@@ -116,7 +118,7 @@ Drop into: `public/case-studies/design-system/`
 
 Suggested filenames (the page already references these):
 
-- [ ] `hero.png` — opening visual (full system overview, component grid, or Figma library shot)
+- [ ] `hero.png` — opening visual (refreshed surface, before/after split, or component grid)
 - [ ] `audit.png` — UI audit findings visualization
 - [ ] `tokens.png` — token architecture diagram
 - [ ] `components.png` — component grid / library
@@ -125,5 +127,7 @@ Suggested filenames (the page already references these):
 Other useful (but not yet referenced):
 
 - [ ] `confluence.png` — documentation source-of-truth shot
-- [ ] `before-after.png` — legacy vs redesigned comparison
-- [ ] anything else that helps tell the story
+- [ ] `before-after.png` — legacy surface vs refreshed surface
+- [ ] `conference.png` — anything from the user conference unveiling
+- [ ] anything else that helps tell the refresh story
+

--- a/content/case-studies/design-system.md
+++ b/content/case-studies/design-system.md
@@ -1,0 +1,129 @@
+# Design System — Intake
+
+Page: `src/app/work/design-system/page.tsx`
+Status: scaffolded, awaiting content
+
+Fill these in (any depth — sentences or bullets, doesn't matter). I'll polish + wire into the page.
+
+---
+
+## OVERVIEW
+
+### timeline
+e.g. "~12 months, June 2024 – present"
+
+→ ANSWER:
+
+### tools & methods — token pipeline
+The page asks: "Style Dictionary? hand-sync? Figma variables → Tailwind config?"
+
+→ ANSWER (be honest — this is a JD "plus" item; we want to claim only what's true):
+
+### the problem (1-line + 2-4 sentences)
+What was fragmented before? What did one-off UI cost the org? Why did this need to exist?
+
+→ 1-line:
+
+→ 2-4 sentences:
+
+### outcome (with at least one number)
+What shipped? Adoption %, components count, regressions avoided, time-to-ship reduction.
+
+→ ANSWER:
+
+---
+
+## DESIGN PROCESS
+
+### research — discovery
+How did you map the existing UI surface area? Audit of inconsistencies. Talking to engineers about what they kept rebuilding.
+
+→ ANSWER:
+
+### research — competitive / reference systems
+Which design systems did you study (Polaris, Carbon, Material, etc.)? What did you take/leave?
+
+→ ANSWER:
+
+### ui audit — framing
+1-2 sentences on what you found across the legacy ASP.NET surface.
+
+→ ANSWER:
+
+### ui audit — insight #1 (heading + 2-3 sentences)
+e.g. "inconsistent spacing"
+
+→ HEADING:
+→ 2-3 SENTENCES:
+
+### ui audit — insight #2 (heading + 2-3 sentences)
+→ HEADING:
+→ 2-3 SENTENCES:
+
+### token architecture
+The token layers — primitive → semantic → component. Where the source of truth lives. How tokens flow from Figma to code.
+
+→ ANSWER:
+
+---
+
+## THE SYSTEM
+
+### components
+Walk through the keystone components. Show variants, states, and the decisions behind them.
+
+→ ANSWER:
+
+### documented states & a11y
+How you documented interaction states + WCAG. (This is the "state modeling, demonstrated in shipped work" requirement — important.)
+
+→ ANSWER:
+
+---
+
+## SYSTEM CONTRIBUTION
+
+### from one-off to reusable
+1-2 concrete examples of feature work that you abstracted into reusable system primitives. Where else are they used now?
+
+→ EXAMPLE 1:
+→ EXAMPLE 2:
+
+### adoption
+How the system spread. Which teams adopted first, the contribution model, how you kept it the easy + right path.
+
+→ ANSWER:
+
+---
+
+## IMPLEMENTATION
+
+### design intent → production code
+The legacy ASP.NET / DevExpress shipping story. Backwards-compatible CSS / JS / C#. How the system landed without regressions.
+
+→ ANSWER:
+
+### documentation
+The single source of truth. Confluence pages, component docs, API references.
+
+→ ANSWER:
+
+---
+
+## SCREENSHOTS
+
+Drop into: `public/case-studies/design-system/`
+
+Suggested filenames (the page already references these):
+
+- [ ] `hero.png` — opening visual (full system overview, component grid, or Figma library shot)
+- [ ] `audit.png` — UI audit findings visualization
+- [ ] `tokens.png` — token architecture diagram
+- [ ] `components.png` — component grid / library
+- [ ] `states.png` — state matrix or annotated component states
+
+Other useful (but not yet referenced):
+
+- [ ] `confluence.png` — documentation source-of-truth shot
+- [ ] `before-after.png` — legacy vs redesigned comparison
+- [ ] anything else that helps tell the story

--- a/content/case-studies/rapidpay.md
+++ b/content/case-studies/rapidpay.md
@@ -1,0 +1,64 @@
+# RapidPay — Intake (memory dump)
+
+Page: `src/app/work/rapidpay/page.tsx`
+Status: scaffolded with existing 2 images, awaiting brief blurbs from memory
+
+You said you don't have access to project info anymore — so this is intentionally minimal. Just whatever you can recall in a few sentences. Goal: enough so a clicker doesn't bounce, not a full case study.
+
+---
+
+## OVERVIEW
+
+### scope — context
+1 line on what RapidPay is.
+
+→ ANSWER:
+
+### scope — data first
+1 short constraint, e.g. "validate OCR'd invoice data".
+
+→ ANSWER:
+
+### tools & methods
+The page lists Figma. Any others to add?
+
+→ ANSWER:
+
+### the problem (1-line + 2-4 sentences from memory)
+What was the form for, who used it, what was hard about it?
+
+→ 1-line:
+
+→ 2-4 sentences:
+
+### outcome (from memory, qualitative is fine)
+What changed for users? Any qualitative or quantitative win you remember?
+
+→ ANSWER:
+
+---
+
+## BEFORE & AFTER
+
+The page already includes both `legacy.png` and `spire.png`. Just need brief captions.
+
+### legacy — 1-2 sentences
+What were the legacy UI's pain points?
+
+→ ANSWER:
+
+### redesigned — 1-2 sentences
+What were the redesign's key moves?
+
+→ ANSWER:
+
+---
+
+## SCREENSHOTS
+
+Already in place:
+
+- [x] `public/case-studies/rapidpay/legacy.png`
+- [x] `public/case-studies/rapidpay/spire.png`
+
+No additional screenshots needed unless you find something on an old hard drive.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -125,7 +125,7 @@ export default function Home() {
               <div className="mt-4 text-lg font-normal text-slate-200">
                 Leading design for{" "}
                 <a
-                  href="https://https://www.smartadvocate.com/"
+                  href="https://www.smartadvocate.com/"
                   target="_blank"
                   className="group relative underline decoration-teal-300 hover:decoration-teal-900"
                 >

--- a/src/app/v2/page.tsx
+++ b/src/app/v2/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+// V2 PREVIEW — Single "work" section, JD-ordered
+// Compare against current homepage at /
+// If adopted, replace src/app/page.tsx contents and update Header.jsx links array.
+
+import { useEffect, useState, useRef } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+import { useDimensions } from "@/lib/useDimensions";
+import VerticalText from "@/components/VerticalText";
+import { SocialLink } from "@/components/SocialLink";
+import MeasuredDiv from "@/components/MeasuredDiv";
+import { Card } from "@/components/Card";
+import { Header } from "@/components/Header";
+import { ArrowUpRight } from "lucide-react";
+import { Project, CASE_STUDIES, DEV_PROJECTS } from "@/lib/data";
+import { cn } from "@/lib/utils";
+
+// JD-ordered merged list. Lead with current SmartAdvocate systems work,
+// then prior-org case studies, then side projects.
+const find = (arr: Project[], title: string) =>
+  arr.find((p) => p.title === title);
+
+// Synthetic entry for the not-yet-in-data Site-wide UI Refresh case study
+const UI_REFRESH: Project = {
+  title: "Site-wide UI Refresh",
+  subtitle:
+    "Refreshing an enterprise product end-to-end — and architecting the design system that shipped it.",
+  slug: "/work/design-system",
+  status: "in development",
+  tags: ["Design System", "Tokens", "WCAG", "ASP.NET / DevExpress"],
+};
+
+const WORK: Project[] = [
+  UI_REFRESH,
+  find(DEV_PROJECTS, "AI Toolchain")!,
+  find(CASE_STUDIES, "Bank Reconciliation")!,
+  find(CASE_STUDIES, "RapidPay")!,
+  find(DEV_PROJECTS, "www.steamparty.io")!,
+  find(DEV_PROJECTS, "encounter+")!,
+].filter(Boolean);
+
+const statusColor: Record<string, string> = {
+  deployed: "bg-green-400/10 text-green-300 ring-green-400/40",
+  "in development": "bg-purple-400/10 text-purple-300 ring-purple-400/40",
+  "coming soon": "bg-yellow-400/10 text-yellow-300 ring-yellow-400/40",
+  "proof of concept": "bg-blue-400/10 text-blue-300 ring-blue-400/40",
+};
+
+function MergedWorkCard({ project, index }: { project: Project; index: number }) {
+  const isExternal = project.slug?.startsWith("http");
+  const linkable = !!project.slug;
+  const Tag = linkable ? (isExternal ? "a" : Link) : "div";
+  const linkProps: any = linkable
+    ? isExternal
+      ? { href: project.slug, target: "_blank", rel: "noreferrer" }
+      : { href: project.slug }
+    : {};
+
+  return (
+    <Card
+      divider={true}
+      badge={true}
+      badgeColor="gray"
+      badgeText={`work_0${index + 1}`}
+      uppercase={true}
+      className="ring-teal-300 transition-all ease-out hover:ring-2"
+      title={`work_0${index + 1}`}
+    >
+      <Tag
+        {...linkProps}
+        className={cn(
+          "group/card flex w-full flex-col gap-6 overflow-clip rounded-md text-slate-200 transition-all duration-300 ease-out",
+          linkable && "cursor-pointer",
+        )}
+      >
+        <div className="flex items-start justify-between gap-12">
+          <div className="flex flex-col">
+            <div className="flex items-center gap-3">
+              <span className="text-4xl font-bold">{project.title}</span>
+              {linkable && (
+                <ArrowUpRight className="ml-1 h-7 w-7 text-slate-400 transition-all duration-300 group-hover/card:-translate-y-1 group-hover/card:translate-x-1 group-hover/card:text-teal-300" />
+              )}
+            </div>
+            <span className="mt-3 text-sm lg:text-lg">{project.subtitle}</span>
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <span
+                className={cn(
+                  "inline-flex w-fit items-center rounded-md px-2 py-1 text-xs font-mono uppercase tracking-wider ring-1 ring-inset",
+                  statusColor[project.status] ?? statusColor["in development"],
+                )}
+              >
+                {project.status}
+              </span>
+              {project.tags?.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded-md bg-slate-700/60 px-2 py-1 text-xs font-mono text-slate-300 ring-1 ring-inset ring-slate-600"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {project.image1 && (
+          <Image
+            src={project.image1}
+            alt={project.title}
+            sizes="100vw"
+            style={{ width: "100%", height: "auto" }}
+            className="rounded-md"
+          />
+        )}
+      </Tag>
+    </Card>
+  );
+}
+
+export default function V2Page() {
+  const [activeSection, setActiveSection] = useState("intro");
+  const introRef = useRef<HTMLDivElement | null>(null);
+  const workRef = useRef<HTMLDivElement | null>(null);
+  const { width, height } = useDimensions(introRef);
+
+  useEffect(() => {
+    const sections = [introRef, workRef];
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) setActiveSection(entry.target.id);
+        });
+      },
+      { threshold: 0.25 },
+    );
+    sections.forEach((s) => s.current && observer.observe(s.current));
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="relative mx-auto min-h-screen max-w-screen-2xl lg:flex lg:gap-12">
+      <Header activeSection={activeSection} />
+
+      {/* PREVIEW BANNER */}
+      <div className="fixed left-1/2 top-4 z-50 -translate-x-1/2 rounded-full bg-purple-400/20 px-4 py-2 text-xs font-mono uppercase text-purple-200 ring-1 ring-purple-400/40 backdrop-blur-sm">
+        preview · v2 · merged work · <a href="/" className="underline hover:text-teal-300">/</a> · <a href="/v3" className="underline hover:text-teal-300">/v3</a>
+      </div>
+
+      <main className="w-full pb-6 md:pb-14 lg:w-5/6 lg:pb-24">
+        <div className="fixed inset-0 -z-20 h-full w-full bg-[radial-gradient(#334155_1px,transparent_1px)] [background-size:16px_16px] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_60%,transparent_100%)]"></div>
+
+        {/* Intro */}
+        <section
+          ref={introRef}
+          id="intro"
+          className="relative flex flex-col gap-12 overflow-hidden px-6 py-12 text-3xl text-slate-200 md:px-12 md:py-20 lg:py-24 lg:pb-24"
+        >
+          <div className="flex w-full gap-12">
+            <span className="flex flex-col font-bold tracking-tight text-slate-200">
+              <span className="text-5xl lg:text-7xl">Dylan Smith</span>
+              <span className="mt-4 flex flex-wrap gap-2 text-lg font-medium lg:text-2xl">
+                The
+                <MeasuredDiv
+                  parentHeight={height}
+                  parentWidth={width}
+                  guideline1={true}
+                  guideline1Props={{ edge: "bottom" }}
+                  guideline2={true}
+                  guideline2Props={{ edge: "right" }}
+                  measurement={true}
+                  measurementProps={{ edge: "bottom" }}
+                  className="w-fit"
+                >
+                  implementation layer
+                </MeasuredDiv>
+                between design and engineering.
+              </span>
+              <span className="mt-4 max-w-2xl text-lg font-normal lg:text-xl">
+                Solutions-first systems builder turning one-off UI work into
+                reusable, compounding system capabilities. Currently leading
+                design at{" "}
+                <a
+                  href="https://www.smartadvocate.com/"
+                  target="_blank"
+                  className="underline decoration-teal-300 hover:text-teal-300"
+                >
+                  SmartAdvocate
+                </a>
+                .
+              </span>
+              <div className="mt-6 flex gap-3">
+                <SocialLink site="github" />
+                <SocialLink site="linkedin" />
+              </div>
+            </span>
+          </div>
+        </section>
+
+        {/* Work — merged */}
+        <section
+          ref={workRef}
+          id="work"
+          className="relative flex flex-col pb-24 lg:mt-12 lg:flex-row lg:bg-none"
+        >
+          <VerticalText text="work" />
+          <div className="flex w-full flex-col gap-24 px-6">
+            {WORK.map((project, index) => (
+              <MergedWorkCard
+                key={project.title}
+                project={project}
+                index={index}
+              />
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/app/v3/page.tsx
+++ b/src/app/v3/page.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+// V3 PREVIEW — Bento mockup
+// Stats + achievements + case studies in a tiled grid.
+// Tiles either link to a full page (case studies, side projects) or open a
+// popover (stats, achievements). Compare against / and /v2.
+
+import { useState, ReactNode } from "react";
+import Link from "next/link";
+import { ArrowUpRight, X } from "lucide-react";
+import { SocialLink } from "@/components/SocialLink";
+import { cn } from "@/lib/utils";
+
+// ---------- Popover ----------
+
+type PopoverContent = {
+  title: string;
+  body: ReactNode;
+};
+
+function Popover({
+  open,
+  onClose,
+  content,
+}: {
+  open: boolean;
+  onClose: () => void;
+  content: PopoverContent | null;
+}) {
+  if (!open || !content) return null;
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/80 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative mx-6 max-w-2xl rounded-2xl bg-slate-800 p-8 ring-1 ring-slate-600"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-slate-400 hover:text-slate-100"
+          aria-label="Close"
+        >
+          <X className="h-5 w-5" />
+        </button>
+        <h3 className="mb-4 font-mono text-sm uppercase tracking-widest text-teal-300">
+          {content.title}
+        </h3>
+        <div className="text-lg text-slate-100">{content.body}</div>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Tile primitives ----------
+
+function Tile({
+  children,
+  className,
+  onClick,
+  href,
+  external,
+  hoverable = true,
+}: {
+  children: ReactNode;
+  className?: string;
+  onClick?: () => void;
+  href?: string;
+  external?: boolean;
+  hoverable?: boolean;
+}) {
+  const base = cn(
+    "group relative flex flex-col overflow-hidden rounded-2xl bg-slate-800/60 p-6 ring-1 ring-slate-700 transition-all duration-300",
+    hoverable && "hover:bg-slate-800 hover:ring-teal-300/50",
+    className,
+  );
+
+  if (href) {
+    if (external) {
+      return (
+        <a href={href} target="_blank" rel="noreferrer" className={base}>
+          {children}
+        </a>
+      );
+    }
+    return (
+      <Link href={href} className={base}>
+        {children}
+      </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <button onClick={onClick} className={cn(base, "text-left")}>
+        {children}
+      </button>
+    );
+  }
+  return <div className={cn(base, "cursor-default")}>{children}</div>;
+}
+
+function StatTile({
+  number,
+  label,
+  detail,
+  onOpen,
+  className,
+}: {
+  number: string;
+  label: string;
+  detail: PopoverContent;
+  onOpen: (c: PopoverContent) => void;
+  className?: string;
+}) {
+  return (
+    <Tile onClick={() => onOpen(detail)} className={className}>
+      <span className="font-sans text-5xl font-bold leading-none text-teal-300 lg:text-6xl">
+        {number}
+      </span>
+      <span className="mt-3 font-mono text-xs uppercase tracking-widest text-slate-300">
+        {label}
+      </span>
+      <span className="mt-auto pt-4 font-mono text-[10px] uppercase tracking-widest text-slate-500 group-hover:text-teal-300">
+        + tap for detail
+      </span>
+    </Tile>
+  );
+}
+
+function CaseStudyTile({
+  label,
+  title,
+  blurb,
+  href,
+  className,
+}: {
+  label: string;
+  title: string;
+  blurb: string;
+  href: string;
+  className?: string;
+}) {
+  return (
+    <Tile href={href} className={cn("justify-between", className)}>
+      <div>
+        <span className="font-mono text-xs uppercase tracking-widest text-teal-300">
+          {label}
+        </span>
+        <h3 className="mt-3 text-2xl font-bold text-slate-100 lg:text-3xl">
+          {title}
+        </h3>
+        <p className="mt-3 text-sm text-slate-300 lg:text-base">{blurb}</p>
+      </div>
+      <div className="mt-4 flex items-center justify-end">
+        <ArrowUpRight className="h-6 w-6 text-slate-400 transition-all duration-300 group-hover:-translate-y-1 group-hover:translate-x-1 group-hover:text-teal-300" />
+      </div>
+    </Tile>
+  );
+}
+
+function AchievementTile({
+  text,
+  detail,
+  onOpen,
+  className,
+}: {
+  text: string;
+  detail: PopoverContent;
+  onOpen: (c: PopoverContent) => void;
+  className?: string;
+}) {
+  return (
+    <Tile onClick={() => onOpen(detail)} className={className}>
+      <span className="font-mono text-xs uppercase tracking-widest text-orange-300">
+        achievement
+      </span>
+      <p className="mt-3 text-base font-medium text-slate-100 lg:text-lg">
+        {text}
+      </p>
+      <span className="mt-auto pt-4 font-mono text-[10px] uppercase tracking-widest text-slate-500 group-hover:text-teal-300">
+        + tap for story
+      </span>
+    </Tile>
+  );
+}
+
+function SideProjectTile({
+  title,
+  blurb,
+  href,
+  className,
+}: {
+  title: string;
+  blurb: string;
+  href: string;
+  className?: string;
+}) {
+  return (
+    <Tile href={href} external className={cn("justify-between", className)}>
+      <div>
+        <span className="font-mono text-xs uppercase tracking-widest text-slate-400">
+          side project
+        </span>
+        <h3 className="mt-3 text-xl font-bold text-slate-100">{title}</h3>
+        <p className="mt-3 text-sm text-slate-300">{blurb}</p>
+      </div>
+      <div className="mt-4 flex items-center justify-end">
+        <ArrowUpRight className="h-5 w-5 text-slate-400 transition-all duration-300 group-hover:-translate-y-1 group-hover:translate-x-1 group-hover:text-teal-300" />
+      </div>
+    </Tile>
+  );
+}
+
+// ---------- Page ----------
+
+export default function V3Page() {
+  const [popover, setPopover] = useState<PopoverContent | null>(null);
+  const open = (c: PopoverContent) => setPopover(c);
+  const close = () => setPopover(null);
+
+  return (
+    <div className="relative min-h-screen bg-slate-900 text-slate-100">
+      <div className="fixed inset-0 -z-20 h-full w-full bg-[radial-gradient(#334155_1px,transparent_1px)] [background-size:16px_16px] [mask-image:radial-gradient(ellipse_60%_60%_at_50%_30%,#000_60%,transparent_100%)]" />
+
+      {/* PREVIEW BANNER */}
+      <div className="fixed left-1/2 top-4 z-40 -translate-x-1/2 rounded-full bg-purple-400/20 px-4 py-2 text-xs font-mono uppercase text-purple-200 ring-1 ring-purple-400/40 backdrop-blur-sm">
+        preview · v3 · bento · <a href="/" className="underline hover:text-teal-300">/</a> · <a href="/v2" className="underline hover:text-teal-300">/v2</a>
+      </div>
+
+      <main className="mx-auto max-w-7xl px-6 py-24 lg:py-32">
+        {/* Bento grid */}
+        <div className="grid grid-cols-12 auto-rows-[minmax(140px,auto)] gap-4">
+          {/* HERO — 8x2 */}
+          <div className="col-span-12 row-span-2 rounded-2xl bg-gradient-to-br from-slate-800 to-slate-900 p-8 ring-1 ring-slate-700 lg:col-span-8 lg:p-10">
+            <span className="font-mono text-xs uppercase tracking-widest text-teal-300">
+              Dylan Smith — UX Engineer
+            </span>
+            <h1 className="mt-4 text-5xl font-bold leading-tight text-slate-100 lg:text-6xl">
+              The implementation layer between design and engineering.
+            </h1>
+            <p className="mt-6 max-w-2xl text-lg text-slate-300">
+              Solutions-first systems builder turning one-off UI work into
+              reusable, compounding system capabilities. Design systems shipped
+              at two organizations, in legacy ASP.NET and modern React.
+            </p>
+            <div className="mt-6 flex gap-3">
+              <SocialLink site="github" />
+              <SocialLink site="linkedin" />
+            </div>
+          </div>
+
+          {/* HEADLINE STATS — 2 stacked tiles 4x1 each */}
+          <StatTile
+            number="10+"
+            label="Years shipping"
+            detail={{
+              title: "10+ years in the overlap",
+              body: (
+                <p>
+                  Living between product design, front-end development, and
+                  database architecture since 2014. Started in software support,
+                  shipped financial reports, then data migration, then design
+                  leadership, then UX engineering. The throughline:
+                  building tools and systems that make work easier for the team.
+                </p>
+              ),
+            }}
+            onOpen={open}
+            className="col-span-6 lg:col-span-4"
+          />
+          <StatTile
+            number="2"
+            label="Design systems shipped"
+            detail={{
+              title: "Two design systems, two organizations",
+              body: (
+                <ul className="list-inside list-disc space-y-2">
+                  <li>
+                    <strong>SmartAdvocate (current):</strong> Architected the
+                    org&apos;s first design system — token architecture,
+                    component variants, documented interaction states, WCAG
+                    from day one.
+                  </li>
+                  <li>
+                    <strong>MDS (prior):</strong> Founded and scaled the
+                    company&apos;s first design system using atomic
+                    methodology; partnered with engineering on tokens as a
+                    shared source of truth.
+                  </li>
+                </ul>
+              ),
+            }}
+            onOpen={open}
+            className="col-span-6 lg:col-span-4"
+          />
+
+          {/* TWO BIG CASE STUDIES */}
+          <CaseStudyTile
+            label="case study · current · systems"
+            title="Site-wide UI Refresh"
+            blurb="Refreshing an enterprise product end-to-end — and architecting the org's first design system underneath. Unveiled at the annual user conference."
+            href="/work/design-system"
+            className="col-span-12 row-span-2 lg:col-span-6"
+          />
+          <CaseStudyTile
+            label="case study · current · ai tooling"
+            title="AI Toolchain"
+            blurb="Claude Code skills, agents, and MCP-driven workflows producing code-ready output. Adopted across teams for design system implementation and data migration."
+            href="/work/ai-tooling"
+            className="col-span-12 row-span-2 lg:col-span-6"
+          />
+
+          {/* IMPACT STATS ROW — 4 tiles */}
+          <StatTile
+            number="60%"
+            label="Turnaround reduction"
+            detail={{
+              title: "60% faster turnaround across 12+ projects",
+              body: (
+                <p>
+                  Treated each data migration engagement as an opportunity to
+                  build reusable team infrastructure rather than ship one-off
+                  scripts. Built a starter-kit monorepo (project boilerplate,
+                  curated migration scripts, shared tooling, CI/CD) and a
+                  Python CLI for terminal-based DB ops — both adopted as team
+                  standards.
+                </p>
+              ),
+            }}
+            onOpen={open}
+            className="col-span-6 lg:col-span-3"
+          />
+          <StatTile
+            number="50%"
+            label="Time-to-ship cut"
+            detail={{
+              title: "50% time-to-ship reduction at MDS",
+              body: (
+                <p>
+                  Overhauled the feature handoff process in partnership with
+                  product owners — reducing time-to-ship by 50% and improving
+                  cross-surface cohesion. Co-owned decisions with engineering
+                  rather than passing handoff loops back and forth.
+                </p>
+              ),
+            }}
+            onOpen={open}
+            className="col-span-6 lg:col-span-3"
+          />
+          <StatTile
+            number="1k+"
+            label="Daily users served"
+            detail={{
+              title: "1,000+ daily users at MDS",
+              body: (
+                <p>
+                  Led design from concept to production for several keystone
+                  features serving 1,000+ daily users at MDS Property
+                  Management — including UX research, UI design, stakeholder
+                  feedback, and developer collaboration.
+                </p>
+              ),
+            }}
+            onOpen={open}
+            className="col-span-6 lg:col-span-3"
+          />
+          <StatTile
+            number="12+"
+            label="Concurrent projects"
+            detail={{
+              title: "12+ concurrent migration projects",
+              body: (
+                <p>
+                  Lead engineer on data migration projects for North
+                  America&apos;s foremost property management firm (portfolio
+                  worth $6B). Coordinated strategy meetings with external
+                  decision makers; translated business logic into optimized SQL
+                  database architecture.
+                </p>
+              ),
+            }}
+            onOpen={open}
+            className="col-span-6 lg:col-span-3"
+          />
+
+          {/* PRIOR-ORG CASE STUDIES */}
+          <CaseStudyTile
+            label="case study · prior · feature"
+            title="Bank Reconciliation"
+            blurb="Redesigning an accountant's critical monthly task. Side-by-side data tables with tight visual hierarchy."
+            href="/work/bank-rec"
+            className="col-span-12 row-span-2 lg:col-span-6"
+          />
+          <CaseStudyTile
+            label="case study · prior · feature"
+            title="RapidPay"
+            blurb="Streamlining a complex form for OCR-validated invoices. State-modeling for confidence, validation, and recovery."
+            href="/work/rapidpay"
+            className="col-span-12 row-span-2 lg:col-span-6"
+          />
+
+          {/* ACHIEVEMENT TILES + SOCIALS */}
+          <AchievementTile
+            text="WCAG-aligned accessibility considered from day one of the design system."
+            detail={{
+              title: "Accessibility from the start, not retrofit",
+              body: (
+                <p>
+                  When you&apos;re building the org&apos;s first design system,
+                  you&apos;re writing the rules everyone else will follow. I
+                  wrote WCAG-aligned color contrast, focus states, keyboard
+                  navigation, and ARIA conventions into the foundational
+                  primitives — not as a compliance pass after launch.
+                </p>
+              ),
+            }}
+            onOpen={open}
+            className="col-span-12 lg:col-span-4"
+          />
+          <AchievementTile
+            text="Largest contributor to the internal Confluence knowledge base — evergreen docs for component patterns, conventions, and schemas."
+            detail={{
+              title: "Documentation-first",
+              body: (
+                <p>
+                  A design system without docs is just a Figma file. I&apos;ve
+                  authored hundreds of pages of evergreen technical
+                  documentation — component patterns, system conventions,
+                  database schemas — designed for teams to self-serve from
+                  rather than ping me.
+                </p>
+              ),
+            }}
+            onOpen={open}
+            className="col-span-12 lg:col-span-4"
+          />
+          <Tile className="col-span-12 justify-between lg:col-span-4">
+            <div>
+              <span className="font-mono text-xs uppercase tracking-widest text-slate-400">
+                more
+              </span>
+              <p className="mt-3 text-base text-slate-200">
+                Resume · GitHub · LinkedIn
+              </p>
+            </div>
+            <div className="mt-4 flex gap-3">
+              <a
+                href="/dylan-smith-resume.pdf"
+                target="_blank"
+                className="rounded-md bg-teal-300 px-4 py-2 font-mono text-xs uppercase text-teal-900 hover:bg-teal-400"
+              >
+                Resume
+              </a>
+              <SocialLink site="github" />
+              <SocialLink site="linkedin" />
+            </div>
+          </Tile>
+
+          {/* SIDE PROJECTS + SKILLS */}
+          <SideProjectTile
+            title="SteamParty"
+            blurb="Find Steam games friends own. React, React Query, Tailwind."
+            href="https://www.steamparty.io"
+            className="col-span-12 lg:col-span-4"
+          />
+          <SideProjectTile
+            title="encounter+"
+            blurb="A customizable DM screen for tabletop RPG sessions. Next.js, Firebase."
+            href="https://github.com/dylpckl/encounter-plus"
+            className="col-span-12 lg:col-span-4"
+          />
+          <Tile className="col-span-12 lg:col-span-4">
+            <span className="font-mono text-xs uppercase tracking-widest text-slate-400">
+              stack
+            </span>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {[
+                "TypeScript",
+                "React",
+                "Next.js",
+                "Tailwind",
+                "Figma",
+                "Design Tokens",
+                "Claude Code",
+                "MCP",
+                "Python",
+                "SQL Server",
+                "PostgreSQL",
+                "Prisma",
+              ].map((skill) => (
+                <span
+                  key={skill}
+                  className="rounded-md bg-slate-700/60 px-2 py-1 font-mono text-xs text-slate-300 ring-1 ring-inset ring-slate-600"
+                >
+                  {skill}
+                </span>
+              ))}
+            </div>
+          </Tile>
+        </div>
+      </main>
+
+      <Popover open={!!popover} onClose={close} content={popover} />
+    </div>
+  );
+}

--- a/src/app/work/ai-tooling/page.tsx
+++ b/src/app/work/ai-tooling/page.tsx
@@ -115,7 +115,7 @@ const CaseStudySection = forwardRef<HTMLDivElement, CaseStudySectionProps>(
       <section
         ref={ref}
         className={cn(
-          "relative mx-auto mt-24 flex gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
+          "relative mx-auto mt-24 flex gap-12 px-6 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
           className,
         )}
       >
@@ -175,7 +175,7 @@ export default function Page() {
       <Header activeSection={activeSection} />
       <div className="w-full">
         {/* Hero */}
-        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
+        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 px-6 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
           {/* Back Button */}
           <div className="flex items-center gap-6 text-teal-300">
             <Link href="/#">
@@ -201,7 +201,7 @@ export default function Page() {
           </div>
           {/* Headline */}
           <div ref={headlineRef} className="mt-12 max-w-5xl text-slate-100">
-            <h1 className="font-sans text-6xl font-bold capitalize leading-relaxed">
+            <h1 className="font-sans text-4xl font-bold capitalize leading-relaxed md:text-6xl">
               <MeasuredDiv
                 guideline1={true}
                 guideline1Props={{ edge: "left" }}
@@ -227,7 +227,7 @@ export default function Page() {
         {/* Overview */}
         <CaseStudySection number={1} title="overview" ref={overviewRef}>
           <div className="flex w-full flex-col gap-12">
-            <div className="flex gap-6">
+            <div className="flex flex-col gap-6 md:flex-row">
               {OVERVIEW_STATS.map(({ title, content }, index) => (
                 <Card
                   title={title}

--- a/src/app/work/ai-tooling/page.tsx
+++ b/src/app/work/ai-tooling/page.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+// External
+import { useEffect, useState, useRef, forwardRef } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+// Utilities
+import { cn } from "@/lib/utils";
+import { useDimensions } from "@/lib/useDimensions";
+
+// Icons
+import {
+  WrenchScrewdriverIcon,
+  UserIcon,
+  ClipboardDocumentCheckIcon,
+  QuestionMarkCircleIcon,
+  ViewfinderCircleIcon,
+  CommandLineIcon,
+  CpuChipIcon,
+  CodeBracketIcon,
+} from "@heroicons/react/24/outline";
+import { Microscope, Sparkles, Bot } from "lucide-react";
+
+// Components
+import VerticalText from "@/components/VerticalText";
+import { ReactNode } from "react";
+import { Card } from "@/components/Card";
+import MeasuredDiv from "@/components/MeasuredDiv";
+import { Header } from "@/components/Header";
+
+// Images
+// TODO: drop hero + supporting images into /public/case-studies/ai-tooling/
+//       then uncomment imports below.
+// import Hero from "/public/case-studies/ai-tooling/hero.png";
+
+const OVERVIEW_STATS = [
+  {
+    title: "roles",
+    icon: UserIcon,
+    content: (
+      <div className="flex flex-col gap-4">
+        <span className="font-semibold text-orange-200">
+          As the toolchain author, I was responsible for:
+          <ul className="list-inside list-disc font-normal text-slate-100">
+            <li>Skill, agent & MCP workflow design</li>
+            <li>Prompt engineering</li>
+            <li>Code-ready output generation</li>
+            <li>Team rollout & docs</li>
+          </ul>
+        </span>
+        <span className="font-semibold text-orange-200">
+          Adopted by:
+          <ul className="list-inside list-disc font-normal capitalize text-slate-100">
+            <li>design system implementation team</li>
+            <li>data migration team</li>
+            <li>{"{TODO: any other teams}"}</li>
+          </ul>
+        </span>
+      </div>
+    ),
+  },
+  {
+    title: "scope & constraints",
+    icon: ViewfinderCircleIcon,
+    content: (
+      <div>
+        <ol className="list-inside list-decimal">
+          <li>
+            <span className="font-semibold capitalize text-orange-200">
+              timeline:
+            </span>{" "}
+            <span>{"{TODO: timeline}"}</span>
+          </li>
+          <li>
+            <span className="font-semibold capitalize text-orange-200">
+              output bar:
+            </span>{" "}
+            <span>code-ready, not just suggestions</span>
+          </li>
+          <li>
+            <span className="font-semibold capitalize text-orange-200">
+              team-first:
+            </span>{" "}
+            <span>built to be adopted, not just used by me</span>
+          </li>
+        </ol>
+      </div>
+    ),
+  },
+  {
+    title: "tools & methods",
+    icon: WrenchScrewdriverIcon,
+    content: (
+      <ul className="list-inside list-disc">
+        <li>Claude Code (skills + agents)</li>
+        <li>Model Context Protocol (MCP)</li>
+        <li>Python / TypeScript</li>
+        <li>{"{TODO: any other tools — Code Sandbox? Cursor?}"}</li>
+      </ul>
+    ),
+  },
+];
+
+type CaseStudySectionProps = {
+  number: number;
+  title: string;
+  className?: string;
+  children: ReactNode;
+};
+
+const CaseStudySection = forwardRef<HTMLDivElement, CaseStudySectionProps>(
+  function CaseStudySection({ number, title, className, children }, ref) {
+    return (
+      <section
+        ref={ref}
+        className={cn(
+          "relative mx-auto mt-24 flex gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
+          className,
+        )}
+      >
+        <VerticalText caption={number} text={title} />
+        {children}
+      </section>
+    );
+  },
+);
+
+const ImagePlaceholder = ({ label }: { label: string }) => (
+  <div className="flex h-96 w-full items-center justify-center rounded-lg border border-dashed border-slate-500 bg-slate-700/40 text-sm font-mono text-slate-400">
+    {label}
+  </div>
+);
+
+export default function Page() {
+  const [activeSection, setActiveSection] = useState("");
+  const headlineRef = useRef<HTMLDivElement | null>(null);
+  const overviewRef = useRef<HTMLDivElement | null>(null);
+  const originRef = useRef<HTMLDivElement | null>(null);
+  const toolkitRef = useRef<HTMLDivElement | null>(null);
+  const adoptionRef = useRef<HTMLDivElement | null>(null);
+  const implementationRef = useRef<HTMLDivElement | null>(null);
+  const { width, height } = useDimensions(headlineRef);
+
+  useEffect(() => {
+    let sections = [
+      overviewRef,
+      originRef,
+      toolkitRef,
+      adoptionRef,
+      implementationRef,
+    ];
+
+    const observerOptions = {
+      root: null,
+      rootMargin: "0px",
+      threshold: 0.25,
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setActiveSection(entry.target.id);
+        }
+      });
+    }, observerOptions);
+
+    sections?.forEach((section) => {
+      section.current && observer.observe(section.current);
+    });
+  }, []);
+
+  return (
+    <div className="mx-auto flex gap-16">
+      <Header activeSection={activeSection} />
+      <div className="w-full">
+        {/* Hero */}
+        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
+          {/* Back Button */}
+          <div className="flex items-center gap-6 text-teal-300">
+            <Link href="/#">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="h-4 w-4 transition-transform duration-300 ease-in-out hover:-translate-x-2"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+                />
+              </svg>
+            </Link>
+            <div className="font-mono text-sm uppercase">
+              <span className="font-semibold">AI 01 {" \\"}</span>
+              <span className="ml-4">AI Toolchain for Design + Engineering</span>
+            </div>
+          </div>
+          {/* Headline */}
+          <div ref={headlineRef} className="mt-12 max-w-5xl text-slate-100">
+            <h1 className="font-sans text-6xl font-bold capitalize leading-relaxed">
+              <MeasuredDiv
+                guideline1={true}
+                guideline1Props={{ edge: "left" }}
+                guideline2={true}
+                guideline2Props={{ edge: "right" }}
+                parentHeight={height}
+                parentWidth={width}
+                measurement={true}
+                measurementProps={{ edge: "bottom" }}
+                className="w-fit"
+              >
+                Building
+              </MeasuredDiv>
+              an AI toolchain for code-ready output
+            </h1>
+          </div>
+          {/* Hero Image */}
+          <div className="relative mt-12 flex h-full w-full justify-center">
+            <ImagePlaceholder label="hero image — drop into /public/case-studies/ai-tooling/hero.png" />
+          </div>
+        </section>
+
+        {/* Overview */}
+        <CaseStudySection number={1} title="overview" ref={overviewRef}>
+          <div className="flex w-full flex-col gap-12">
+            <div className="flex gap-6">
+              {OVERVIEW_STATS.map(({ title, content }, index) => (
+                <Card
+                  title={title}
+                  divider={false}
+                  key={index}
+                  className="flex flex-col gap-4"
+                >
+                  {content}
+                </Card>
+              ))}
+            </div>
+            <Card
+              title="the bet"
+              icon={<QuestionMarkCircleIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <div className="mt-6 text-lg">
+                <h2 className="text-xl">
+                  {"{TODO: 1-line thesis — why invest in AI tooling now}"}
+                </h2>
+                <p className="mt-4">
+                  {
+                    "{TODO: 2-4 sentences. The slope you're tracking. Why generic AI assistants weren't enough. What 'code-ready output' means to you.}"
+                  }
+                </p>
+              </div>
+            </Card>
+            <Card
+              title="outcome"
+              divider={true}
+              icon={<ClipboardDocumentCheckIcon className="h-6 w-6" />}
+            >
+              <p className="mt-6 font-sans text-lg font-normal text-slate-100">
+                {
+                  "{TODO: outcome paragraph. Adoption rate, time saved, what kinds of work shifted from manual to automated. At least one concrete number — e.g. '60% turnaround reduction across 12+ projects'.}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* Origin */}
+        <CaseStudySection number={2} title="origin" ref={originRef}>
+          <div className="flex flex-col gap-12">
+            <Card title="the gap" icon={<Microscope />} divider={true}>
+              <p>
+                {
+                  "{TODO: what was happening before — engineers re-writing similar boilerplate, design tokens not surfacing in code suggestions, manual translation between Figma and components, etc.}"
+                }
+              </p>
+            </Card>
+
+            <Card
+              title="design principle: code-ready output"
+              icon={<CommandLineIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: the principle that drove the design — the bar isn't 'plausible suggestion,' it's 'paste-able into prod'. How you operationalized that into prompts, skill scopes, MCP server contracts.}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* The Toolkit */}
+        <CaseStudySection number={3} title="the toolkit" ref={toolkitRef}>
+          <div className="flex w-full flex-col gap-12">
+            <Card
+              title="skills"
+              icon={<Sparkles />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: walk through 1-2 keystone skills. What they do, how they're scoped, what code-ready output they produce. (e.g. 'design-token-emit', 'component-from-figma'.)}"
+                }
+              </p>
+              <div className="mt-6">
+                <ImagePlaceholder label="skill demo — /public/case-studies/ai-tooling/skill-demo.png" />
+              </div>
+            </Card>
+            <Card
+              title="agents"
+              icon={<Bot />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: 1-2 agents you built. Their job, their tools, what success looks like for each.}"
+                }
+              </p>
+            </Card>
+            <Card
+              title="mcp workflows"
+              icon={<CpuChipIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: which MCP servers you stood up or integrated — design system docs MCP? Figma MCP? Internal DB MCP? What the integration unlocked.}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* Adoption */}
+        <CaseStudySection number={4} title="team adoption" ref={adoptionRef}>
+          <div className="flex w-full flex-col gap-12">
+            <Card
+              title="how it spread"
+              icon={<ClipboardDocumentCheckIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: how the toolchain went from your laptop to team standard. Onboarding, internal docs, the team-first design choices.}"
+                }
+              </p>
+            </Card>
+            <Card
+              title="impact"
+              icon={<Sparkles />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: numbers + stories. Concrete examples of work that got faster or higher-quality. Anything that's now possible that wasn't before.}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* Implementation */}
+        <CaseStudySection
+          number={5}
+          title="implementation"
+          ref={implementationRef}
+        >
+          <div className="flex w-full flex-col gap-12">
+            <Card
+              title="how it works under the hood"
+              icon={<CodeBracketIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: technical detail for an engineering reader. Skill anatomy, agent tool wiring, MCP server contracts. Show one or two real prompts/configs if you can share them.}"
+                }
+              </p>
+            </Card>
+            <Card
+              title="where this goes next"
+              icon={<ViewfinderCircleIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: the slope. Where AI-powered design tooling is heading, and where this toolchain is positioned on it. (Cover letter material — also good here.)}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+      </div>
+    </div>
+  );
+}

--- a/src/app/work/bank-rec/page.tsx
+++ b/src/app/work/bank-rec/page.tsx
@@ -191,7 +191,7 @@ export default function Page() {
             </Link>
             <div className="font-mono text-sm uppercase">
               <span className="font-semibold">DSGN 01 {" \\"}</span>
-              <span className="ml-4">Bank Reconcillation</span>
+              <span className="ml-4">Bank Reconciliation</span>
             </div>
           </div>
           {/* Headline */}

--- a/src/app/work/bank-rec/page.tsx
+++ b/src/app/work/bank-rec/page.tsx
@@ -117,7 +117,7 @@ const CaseStudySection = forwardRef<HTMLDivElement, CaseStudySectionProps>(
       <section
         ref={ref}
         className={cn(
-          "relative mx-auto mt-24 flex gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
+          "relative mx-auto mt-24 flex gap-12 px-6 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
           className,
         )}
       >
@@ -170,7 +170,7 @@ export default function Page() {
       <Header activeSection={activeSection} />
       <div className="w-full">
         {/* Hero */}
-        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
+        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 px-6 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
           {/* Back Button */}
           <div className="flex items-center gap-6 text-teal-300">
             <Link href="/#">
@@ -196,7 +196,7 @@ export default function Page() {
           </div>
           {/* Headline */}
           <div ref={headlineRef} className="mt-12 max-w-5xl text-slate-100">
-            <h1 className="font-sans text-6xl font-bold capitalize leading-relaxed">
+            <h1 className="font-sans text-4xl font-bold capitalize leading-relaxed md:text-6xl">
               <MeasuredDiv
                 guideline1={true}
                 guideline1Props={{ edge: "left" }}
@@ -229,7 +229,7 @@ export default function Page() {
         <CaseStudySection number={1} title="overview" ref={overviewRef}>
           {/* Container */}
           <div className="flex w-full flex-col gap-12">
-            <div className="flex gap-6">
+            <div className="flex flex-col gap-6 md:flex-row">
               {OVERVIEW_STATS.map(({ title, content, icon }, index) => (
                 <Card
                   title={title}

--- a/src/app/work/design-system/page.tsx
+++ b/src/app/work/design-system/page.tsx
@@ -204,7 +204,7 @@ export default function Page() {
             </Link>
             <div className="font-mono text-sm uppercase">
               <span className="font-semibold">SYS 01 {" \\"}</span>
-              <span className="ml-4">Design System</span>
+              <span className="ml-4">Site-wide UI Refresh</span>
             </div>
           </div>
           {/* Headline */}
@@ -221,9 +221,9 @@ export default function Page() {
                 measurementProps={{ edge: "bottom" }}
                 className="w-fit"
               >
-                Architecting
+                Refreshing
               </MeasuredDiv>
-              the organization&apos;s first design system
+              an enterprise product &mdash; and the design system underneath
             </h1>
           </div>
           {/* Hero Image */}
@@ -254,11 +254,11 @@ export default function Page() {
             >
               <div className="mt-6 text-lg">
                 <h2 className="text-xl">
-                  {"{TODO: 1-line problem statement}"}
+                  {"{TODO: 1-line framing — the product needed a refresh, but the org had no system to refresh it on}"}
                 </h2>
                 <p className="mt-4">
                   {
-                    "{TODO: 2-4 sentences. What was fragmented? What did one-off UI cost the org? Why did this need to exist?}"
+                    "{TODO: 2-4 sentences. Years of accumulated UI debt. Fragmented patterns across the legacy ASP.NET/DevExpress surface. Why a piecemeal rework wouldn't scale — and why the refresh and the design system had to ship together.}"
                   }
                 </p>
               </div>
@@ -270,7 +270,7 @@ export default function Page() {
             >
               <p className="mt-6 font-sans text-lg font-normal text-slate-100">
                 {
-                  "{TODO: outcome paragraph. Lead with what shipped. Include at least one concrete number — adoption %, components shipped, regressions avoided, time-to-ship reduction.}"
+                  "{TODO: outcome paragraph. The refresh was unveiled at the annual user conference. Lead with what shipped — surfaces refreshed, components in production, regressions avoided. Include at least one concrete number.}"
                 }
               </p>
             </Card>

--- a/src/app/work/design-system/page.tsx
+++ b/src/app/work/design-system/page.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+// External
+import { useEffect, useState, useRef, forwardRef } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+// Utilities
+import { cn } from "@/lib/utils";
+import { useDimensions } from "@/lib/useDimensions";
+
+// Icons
+import {
+  WrenchScrewdriverIcon,
+  UserIcon,
+  ClipboardDocumentCheckIcon,
+  QuestionMarkCircleIcon,
+  ViewfinderCircleIcon,
+  PuzzlePieceIcon,
+  CodeBracketIcon,
+} from "@heroicons/react/24/outline";
+import { Microscope, Frame, ScanSearch, Sparkles } from "lucide-react";
+
+// Components
+import VerticalText from "@/components/VerticalText";
+import { ReactNode } from "react";
+import { Card } from "@/components/Card";
+import MeasuredDiv from "@/components/MeasuredDiv";
+import { Header } from "@/components/Header";
+
+// Images
+// TODO: drop hero + supporting images into /public/case-studies/design-system/
+//       then uncomment imports below.
+// import Hero from "/public/case-studies/design-system/hero.png";
+// import Tokens from "/public/case-studies/design-system/tokens.png";
+// import Components from "/public/case-studies/design-system/components.png";
+
+const OVERVIEW_STATS = [
+  {
+    title: "roles",
+    icon: UserIcon,
+    content: (
+      <div className="flex flex-col gap-4">
+        <span className="font-semibold text-orange-200">
+          As the sole designer & developer, I was responsible for:
+          <ul className="list-inside list-disc font-normal text-slate-100">
+            <li>Token architecture</li>
+            <li>Component design & engineering</li>
+            <li>Documentation</li>
+            <li>Accessibility</li>
+            <li>Production rollout</li>
+          </ul>
+        </span>
+        <span className="font-semibold text-orange-200">
+          In collaboration with:
+          <ul className="list-inside list-disc font-normal capitalize text-slate-100">
+            <li>front-end & back-end developers</li>
+            <li>product managers</li>
+            <li>end users at annual user conference</li>
+          </ul>
+        </span>
+      </div>
+    ),
+  },
+  {
+    title: "scope & constraints",
+    icon: ViewfinderCircleIcon,
+    content: (
+      <div>
+        <ol className="list-inside list-decimal">
+          <li>
+            <span className="font-semibold capitalize text-orange-200">
+              timeline:
+            </span>{" "}
+            <span>{"{TODO: timeline — e.g. ~12 months}"}</span>
+          </li>
+          <li>
+            <span className="font-semibold capitalize text-orange-200">
+              legacy stack:
+            </span>{" "}
+            <span>
+              ASP.NET / DevExpress production codebase, no regressions
+              tolerated
+            </span>
+          </li>
+          <li>
+            <span className="font-semibold capitalize text-orange-200">
+              first of its kind:
+            </span>{" "}
+            <span>
+              No prior design system at the org — building from zero
+            </span>
+          </li>
+        </ol>
+      </div>
+    ),
+  },
+  {
+    title: "tools & methods",
+    icon: WrenchScrewdriverIcon,
+    content: (
+      <ul className="list-inside list-disc">
+        <li>Figma (variables, components, variants)</li>
+        <li>TypeScript / React / Tailwind</li>
+        <li>{"{TODO: token pipeline tool — Style Dictionary? hand-sync?}"}</li>
+        <li>Confluence (documentation)</li>
+        <li>WCAG accessibility</li>
+      </ul>
+    ),
+  },
+];
+
+type CaseStudySectionProps = {
+  number: number;
+  title: string;
+  className?: string;
+  children: ReactNode;
+};
+
+const CaseStudySection = forwardRef<HTMLDivElement, CaseStudySectionProps>(
+  function CaseStudySection({ number, title, className, children }, ref) {
+    return (
+      <section
+        ref={ref}
+        className={cn(
+          "relative mx-auto mt-24 flex gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
+          className,
+        )}
+      >
+        <VerticalText caption={number} text={title} />
+        {children}
+      </section>
+    );
+  },
+);
+
+const ImagePlaceholder = ({ label }: { label: string }) => (
+  <div className="flex h-96 w-full items-center justify-center rounded-lg border border-dashed border-slate-500 bg-slate-700/40 text-sm font-mono text-slate-400">
+    {label}
+  </div>
+);
+
+export default function Page() {
+  const [activeSection, setActiveSection] = useState("");
+  const headlineRef = useRef<HTMLDivElement | null>(null);
+  const overviewRef = useRef<HTMLDivElement | null>(null);
+  const designProcessRef = useRef<HTMLDivElement | null>(null);
+  const finalRef = useRef<HTMLDivElement | null>(null);
+  const systemRef = useRef<HTMLDivElement | null>(null);
+  const implementationRef = useRef<HTMLDivElement | null>(null);
+  const { width, height } = useDimensions(headlineRef);
+
+  useEffect(() => {
+    let sections = [
+      overviewRef,
+      designProcessRef,
+      finalRef,
+      systemRef,
+      implementationRef,
+    ];
+
+    const observerOptions = {
+      root: null,
+      rootMargin: "0px",
+      threshold: 0.25,
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setActiveSection(entry.target.id);
+        }
+      });
+    }, observerOptions);
+
+    sections?.forEach((section) => {
+      section.current && observer.observe(section.current);
+    });
+  }, []);
+
+  return (
+    <div className="mx-auto flex gap-16">
+      <Header activeSection={activeSection} />
+      <div className="w-full">
+        {/* Hero */}
+        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
+          {/* Back Button */}
+          <div className="flex items-center gap-6 text-teal-300">
+            <Link href="/#">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="h-4 w-4 transition-transform duration-300 ease-in-out hover:-translate-x-2"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+                />
+              </svg>
+            </Link>
+            <div className="font-mono text-sm uppercase">
+              <span className="font-semibold">SYS 01 {" \\"}</span>
+              <span className="ml-4">Design System</span>
+            </div>
+          </div>
+          {/* Headline */}
+          <div ref={headlineRef} className="mt-12 max-w-5xl text-slate-100">
+            <h1 className="font-sans text-6xl font-bold capitalize leading-relaxed">
+              <MeasuredDiv
+                guideline1={true}
+                guideline1Props={{ edge: "left" }}
+                guideline2={true}
+                guideline2Props={{ edge: "right" }}
+                parentHeight={height}
+                parentWidth={width}
+                measurement={true}
+                measurementProps={{ edge: "bottom" }}
+                className="w-fit"
+              >
+                Architecting
+              </MeasuredDiv>
+              the organization&apos;s first design system
+            </h1>
+          </div>
+          {/* Hero Image */}
+          <div className="relative mt-12 flex h-full w-full justify-center">
+            <ImagePlaceholder label="hero image — drop into /public/case-studies/design-system/hero.png" />
+          </div>
+        </section>
+
+        {/* Overview */}
+        <CaseStudySection number={1} title="overview" ref={overviewRef}>
+          <div className="flex w-full flex-col gap-12">
+            <div className="flex gap-6">
+              {OVERVIEW_STATS.map(({ title, content }, index) => (
+                <Card
+                  title={title}
+                  divider={false}
+                  key={index}
+                  className="flex flex-col gap-4"
+                >
+                  {content}
+                </Card>
+              ))}
+            </div>
+            <Card
+              title="the problem"
+              icon={<QuestionMarkCircleIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <div className="mt-6 text-lg">
+                <h2 className="text-xl">
+                  {"{TODO: 1-line problem statement}"}
+                </h2>
+                <p className="mt-4">
+                  {
+                    "{TODO: 2-4 sentences. What was fragmented? What did one-off UI cost the org? Why did this need to exist?}"
+                  }
+                </p>
+              </div>
+            </Card>
+            <Card
+              title="outcome"
+              divider={true}
+              icon={<ClipboardDocumentCheckIcon className="h-6 w-6" />}
+            >
+              <p className="mt-6 font-sans text-lg font-normal text-slate-100">
+                {
+                  "{TODO: outcome paragraph. Lead with what shipped. Include at least one concrete number — adoption %, components shipped, regressions avoided, time-to-ship reduction.}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* Design Process */}
+        <CaseStudySection
+          number={2}
+          title="design process"
+          ref={designProcessRef}
+        >
+          <div className="flex flex-col gap-12">
+            <Card title="research" icon={<Microscope />} divider={true}>
+              <h2 className="text-lg font-semibold capitalize text-orange-200">
+                discovery
+              </h2>
+              <p>
+                {
+                  "{TODO: how you mapped the existing UI surface area. Audit of inconsistencies. Talking to engineers about what they kept rebuilding.}"
+                }
+              </p>
+              <h2 className="mt-6 text-lg font-semibold capitalize text-orange-200">
+                competitive / reference systems
+              </h2>
+              <p>
+                {
+                  "{TODO: which design systems you studied (Polaris, Carbon, Material, etc.) and what you took/left.}"
+                }
+              </p>
+            </Card>
+
+            <Card title="ui audit" icon={<ScanSearch />} divider={true}>
+              <div className="flex flex-col gap-6">
+                {
+                  "{TODO: 1-2 sentences framing the audit — what you found across the legacy ASP.NET surface.}"
+                }
+                <div className="flex flex-col">
+                  <h2 className="text-lg font-semibold text-orange-200">
+                    {"{TODO: audit insight #1 — e.g. inconsistent spacing}"}
+                  </h2>
+                  <p>{"{TODO: 2-3 sentences with a specific example.}"}</p>
+                </div>
+                <div className="flex flex-col">
+                  <h2 className="text-lg font-semibold text-orange-200">
+                    {"{TODO: audit insight #2}"}
+                  </h2>
+                  <p>{"{TODO: 2-3 sentences.}"}</p>
+                </div>
+              </div>
+              <div className="mt-6">
+                <ImagePlaceholder label="audit image — /public/case-studies/design-system/audit.png" />
+              </div>
+            </Card>
+
+            <Card title="token architecture" icon={<Frame />} divider={true}>
+              <p>
+                {
+                  "{TODO: explain the token layers — primitive → semantic → component. Where the source of truth lives. How tokens flow from Figma to code.}"
+                }
+              </p>
+              <div className="mt-6">
+                <ImagePlaceholder label="token diagram — /public/case-studies/design-system/tokens.png" />
+              </div>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* Final Prototype */}
+        <CaseStudySection number={3} title="the system" ref={finalRef}>
+          <div className="flex w-full flex-col gap-12">
+            <Card
+              title="components"
+              icon={<PuzzlePieceIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: walk through the keystone components. Show variants, states, and the decisions behind them.}"
+                }
+              </p>
+              <div className="mt-6">
+                <ImagePlaceholder label="component grid — /public/case-studies/design-system/components.png" />
+              </div>
+            </Card>
+            <Card
+              title="documented states & a11y"
+              icon={<ViewfinderCircleIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: how you documented interaction states and WCAG considerations from the start. Show a state matrix or annotated component if possible.}"
+                }
+              </p>
+              <div className="mt-6">
+                <ImagePlaceholder label="state matrix — /public/case-studies/design-system/states.png" />
+              </div>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* System Contribution */}
+        <CaseStudySection
+          number={4}
+          title="system contribution"
+          ref={systemRef}
+        >
+          <div className="flex w-full flex-col gap-12">
+            <Card
+              title="from one-off to reusable"
+              icon={<Sparkles />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: pick 1-2 concrete examples of feature work that you abstracted into reusable system primitives. Where else are they used now?}"
+                }
+              </p>
+            </Card>
+            <Card
+              title="adoption"
+              icon={<ClipboardDocumentCheckIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: how the system spread. Which teams adopted first, what the contribution model looks like, how you kept it the easy + right path.}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* Implementation */}
+        <CaseStudySection
+          number={5}
+          title="implementation"
+          ref={implementationRef}
+        >
+          <div className="flex w-full flex-col gap-12">
+            <Card
+              title="design intent → production code"
+              icon={<CodeBracketIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: the legacy ASP.NET / DevExpress shipping story. Backwards-compatible CSS / JS / C#. How the system landed without regressions.}"
+                }
+              </p>
+            </Card>
+            <Card
+              title="documentation"
+              icon={<ClipboardDocumentCheckIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <p>
+                {
+                  "{TODO: the single source of truth. Confluence pages, component docs, API references. What teams can self-serve from.}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+      </div>
+    </div>
+  );
+}

--- a/src/app/work/design-system/page.tsx
+++ b/src/app/work/design-system/page.tsx
@@ -123,7 +123,7 @@ const CaseStudySection = forwardRef<HTMLDivElement, CaseStudySectionProps>(
       <section
         ref={ref}
         className={cn(
-          "relative mx-auto mt-24 flex gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
+          "relative mx-auto mt-24 flex gap-12 px-6 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
           className,
         )}
       >
@@ -183,7 +183,7 @@ export default function Page() {
       <Header activeSection={activeSection} />
       <div className="w-full">
         {/* Hero */}
-        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
+        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 px-6 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
           {/* Back Button */}
           <div className="flex items-center gap-6 text-teal-300">
             <Link href="/#">
@@ -209,7 +209,7 @@ export default function Page() {
           </div>
           {/* Headline */}
           <div ref={headlineRef} className="mt-12 max-w-5xl text-slate-100">
-            <h1 className="font-sans text-6xl font-bold capitalize leading-relaxed">
+            <h1 className="font-sans text-4xl font-bold capitalize leading-relaxed md:text-6xl">
               <MeasuredDiv
                 guideline1={true}
                 guideline1Props={{ edge: "left" }}
@@ -235,7 +235,7 @@ export default function Page() {
         {/* Overview */}
         <CaseStudySection number={1} title="overview" ref={overviewRef}>
           <div className="flex w-full flex-col gap-12">
-            <div className="flex gap-6">
+            <div className="flex flex-col gap-6 md:flex-row">
               {OVERVIEW_STATS.map(({ title, content }, index) => (
                 <Card
                   title={title}

--- a/src/app/work/page.jsx
+++ b/src/app/work/page.jsx
@@ -103,14 +103,14 @@ export default function PostIndex() {
                 </p>
                 <div>
                   <p className="text-sm mt-2">
-                    As the lead UI/UX Designer, I created the project&apos;s
-                    first design system using atomic methodology.
+                    A portfolio site focused on a journeyed user experience
+                    that showcases work and communicates thought process.
                   </p>
                   <p className="text-sm mt-2">
-                    I&apos;ve also lead the design effort from concept to
-                    production for several keystone features with thousands of
-                    daily users, including UX research, UI design, incorporating
-                    stakeholder feedback and developer collaboration.
+                    Built on a custom component library designed specifically
+                    to clearly communicate accomplishments. Combines React
+                    Server and Client components with a static data rendering
+                    strategy for optimal performance.
                   </p>
                 </div>
               </div>

--- a/src/app/work/rapidpay/page.tsx
+++ b/src/app/work/rapidpay/page.tsx
@@ -104,7 +104,7 @@ const CaseStudySection = forwardRef<HTMLDivElement, CaseStudySectionProps>(
       <section
         ref={ref}
         className={cn(
-          "relative mx-auto mt-24 flex gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
+          "relative mx-auto mt-24 flex gap-12 px-6 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
           className,
         )}
       >
@@ -149,7 +149,7 @@ export default function Page() {
       <Header activeSection={activeSection} />
       <div className="w-full">
         {/* Hero */}
-        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
+        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 px-6 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
           {/* Back Button */}
           <div className="flex items-center gap-6 text-teal-300">
             <Link href="/#">
@@ -175,7 +175,7 @@ export default function Page() {
           </div>
           {/* Headline */}
           <div ref={headlineRef} className="mt-12 max-w-5xl text-slate-100">
-            <h1 className="font-sans text-6xl font-bold capitalize leading-relaxed">
+            <h1 className="font-sans text-4xl font-bold capitalize leading-relaxed md:text-6xl">
               <MeasuredDiv
                 guideline1={true}
                 guideline1Props={{ edge: "left" }}
@@ -206,7 +206,7 @@ export default function Page() {
         {/* Overview */}
         <CaseStudySection number={1} title="overview" ref={overviewRef}>
           <div className="flex w-full flex-col gap-12">
-            <div className="flex gap-6">
+            <div className="flex flex-col gap-6 md:flex-row">
               {OVERVIEW_STATS.map(({ title, content }, index) => (
                 <Card
                   title={title}

--- a/src/app/work/rapidpay/page.tsx
+++ b/src/app/work/rapidpay/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+// External
+import { useEffect, useState, useRef, forwardRef } from "react";
+import Image from "next/image";
+import Link from "next/link";
+
+// Utilities
+import { cn } from "@/lib/utils";
+import { useDimensions } from "@/lib/useDimensions";
+
+// Icons
+import {
+  WrenchScrewdriverIcon,
+  UserIcon,
+  ClipboardDocumentCheckIcon,
+  QuestionMarkCircleIcon,
+  ViewfinderCircleIcon,
+} from "@heroicons/react/24/outline";
+
+// Components
+import VerticalText from "@/components/VerticalText";
+import { ReactNode } from "react";
+import { Card } from "@/components/Card";
+import MeasuredDiv from "@/components/MeasuredDiv";
+import { Header } from "@/components/Header";
+
+// Images
+import Legacy from "/public/case-studies/rapidpay/legacy.png";
+import Spire from "/public/case-studies/rapidpay/spire.png";
+
+const OVERVIEW_STATS = [
+  {
+    title: "roles",
+    icon: UserIcon,
+    content: (
+      <div className="flex flex-col gap-4">
+        <span className="font-semibold text-orange-200">
+          As a solo designer, I was responsible for:
+          <ul className="list-inside list-disc font-normal text-slate-100">
+            <li>UX Research</li>
+            <li>UI Design</li>
+          </ul>
+        </span>
+        <span className="font-semibold text-orange-200">
+          In collaboration with:
+          <ul className="list-inside list-disc font-normal capitalize text-slate-100">
+            <li>end users</li>
+            <li>front-end & back-end developers</li>
+            <li>project managers</li>
+          </ul>
+        </span>
+      </div>
+    ),
+  },
+  {
+    title: "scope & constraints",
+    icon: ViewfinderCircleIcon,
+    content: (
+      <div>
+        <ol className="list-inside list-decimal">
+          <li>
+            <span className="font-semibold capitalize text-orange-200">
+              context:
+            </span>{" "}
+            <span>
+              {"{TODO: 1 line on what RapidPay is}"}
+            </span>
+          </li>
+          <li>
+            <span className="font-semibold capitalize text-orange-200">
+              data first:
+            </span>{" "}
+            <span>
+              {"{TODO: short constraint — e.g. validate OCR'd invoice data}"}
+            </span>
+          </li>
+        </ol>
+      </div>
+    ),
+  },
+  {
+    title: "tools & methods",
+    icon: WrenchScrewdriverIcon,
+    content: (
+      <ul className="list-inside list-disc">
+        <li>Figma</li>
+        <li>{"{TODO: any other relevant tools}"}</li>
+      </ul>
+    ),
+  },
+];
+
+type CaseStudySectionProps = {
+  number: number;
+  title: string;
+  className?: string;
+  children: ReactNode;
+};
+
+const CaseStudySection = forwardRef<HTMLDivElement, CaseStudySectionProps>(
+  function CaseStudySection({ number, title, className, children }, ref) {
+    return (
+      <section
+        ref={ref}
+        className={cn(
+          "relative mx-auto mt-24 flex gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24",
+          className,
+        )}
+      >
+        <VerticalText caption={number} text={title} />
+        {children}
+      </section>
+    );
+  },
+);
+
+export default function Page() {
+  const [activeSection, setActiveSection] = useState("");
+  const headlineRef = useRef<HTMLDivElement | null>(null);
+  const overviewRef = useRef<HTMLDivElement | null>(null);
+  const beforeAfterRef = useRef<HTMLDivElement | null>(null);
+  const { width, height } = useDimensions(headlineRef);
+
+  useEffect(() => {
+    let sections = [overviewRef, beforeAfterRef];
+
+    const observerOptions = {
+      root: null,
+      rootMargin: "0px",
+      threshold: 0.25,
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setActiveSection(entry.target.id);
+        }
+      });
+    }, observerOptions);
+
+    sections?.forEach((section) => {
+      section.current && observer.observe(section.current);
+    });
+  }, []);
+
+  return (
+    <div className="mx-auto flex gap-16">
+      <Header activeSection={activeSection} />
+      <div className="w-full">
+        {/* Hero */}
+        <section className="mx-auto mt-16 flex min-h-[80vh] flex-col gap-12 py-12 md:px-12 md:py-20 lg:py-24 lg:pb-24">
+          {/* Back Button */}
+          <div className="flex items-center gap-6 text-teal-300">
+            <Link href="/#">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="h-4 w-4 transition-transform duration-300 ease-in-out hover:-translate-x-2"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
+                />
+              </svg>
+            </Link>
+            <div className="font-mono text-sm uppercase">
+              <span className="font-semibold">DSGN 02 {" \\"}</span>
+              <span className="ml-4">RapidPay</span>
+            </div>
+          </div>
+          {/* Headline */}
+          <div ref={headlineRef} className="mt-12 max-w-5xl text-slate-100">
+            <h1 className="font-sans text-6xl font-bold capitalize leading-relaxed">
+              <MeasuredDiv
+                guideline1={true}
+                guideline1Props={{ edge: "left" }}
+                guideline2={true}
+                guideline2Props={{ edge: "right" }}
+                parentHeight={height}
+                parentWidth={width}
+                measurement={true}
+                measurementProps={{ edge: "bottom" }}
+                className="w-fit"
+              >
+                Streamlining
+              </MeasuredDiv>
+              a complex form for OCR-validated invoices
+            </h1>
+          </div>
+          {/* Hero Image */}
+          <div className="relative mt-12 flex h-full w-full justify-center">
+            <Image
+              src={Spire}
+              alt="RapidPay redesigned interface"
+              style={{ objectFit: "cover", objectPosition: "top" }}
+              className="rounded-lg"
+            />
+          </div>
+        </section>
+
+        {/* Overview */}
+        <CaseStudySection number={1} title="overview" ref={overviewRef}>
+          <div className="flex w-full flex-col gap-12">
+            <div className="flex gap-6">
+              {OVERVIEW_STATS.map(({ title, content }, index) => (
+                <Card
+                  title={title}
+                  divider={false}
+                  key={index}
+                  className="flex flex-col gap-4"
+                >
+                  {content}
+                </Card>
+              ))}
+            </div>
+            <Card
+              title="the problem"
+              icon={<QuestionMarkCircleIcon className="h-6 w-6" />}
+              divider={true}
+            >
+              <div className="mt-6 text-lg">
+                <h2 className="text-xl">
+                  {"{TODO: 1-line problem statement from memory}"}
+                </h2>
+                <p className="mt-4">
+                  {
+                    "{TODO: 2-4 sentences from memory. What the form was for, who used it, what was hard about it.}"
+                  }
+                </p>
+              </div>
+            </Card>
+            <Card
+              title="outcome"
+              divider={true}
+              icon={<ClipboardDocumentCheckIcon className="h-6 w-6" />}
+            >
+              <p className="mt-6 font-sans text-lg font-normal text-slate-100">
+                {
+                  "{TODO: outcome paragraph from memory. What changed for users? Any qualitative or quantitative win.}"
+                }
+              </p>
+            </Card>
+          </div>
+        </CaseStudySection>
+
+        {/* Before / After */}
+        <CaseStudySection
+          number={2}
+          title="before & after"
+          ref={beforeAfterRef}
+        >
+          <div className="flex w-full flex-col gap-12">
+            <Card title="legacy" divider={true}>
+              <p className="mb-6">
+                {
+                  "{TODO: 1-2 sentences from memory describing the legacy UI's pain points.}"
+                }
+              </p>
+              <Image
+                src={Legacy}
+                alt="RapidPay legacy interface"
+                className="rounded-lg"
+              />
+            </Card>
+            <Card title="redesigned" divider={true}>
+              <p className="mb-6">
+                {
+                  "{TODO: 1-2 sentences from memory describing the redesign's key moves.}"
+                }
+              </p>
+              <Image
+                src={Spire}
+                alt="RapidPay redesigned interface"
+                className="rounded-lg"
+              />
+            </Card>
+          </div>
+        </CaseStudySection>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -54,7 +54,7 @@ const DesktopNavigation = (props) => {
         <NavItem href="/about">about</NavItem>
         <span className="text-xs text-slate-400">{"//"}</span>
         <a
-          href="/Dylan-Smith-Resume.pdf"
+          href="/dylan-smith-resume.pdf"
           target="_blank"
           className="p-1 font-mono text-sm text-slate-200 hover:text-teal-300 md:px-3 md:py-2"
         >
@@ -189,7 +189,7 @@ export function Header({ activeSection }) {
         </Link>
         <Nav links={links} activeSection={activeSection} />
         <Link
-          href="/Dylan-Smith-Resume.pdf"
+          href="/dylan-smith-resume.pdf"
           target="_blank"
           className="mt-6 flex cursor-pointer gap-4 pt-6 font-mono text-sm font-semibold uppercase text-slate-200"
         >

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -44,10 +44,10 @@ export type CaseStudy = {
 
 export const CASE_STUDIES: Project[] = [
   {
-    title: "Bank Reconcilation",
+    title: "Bank Reconciliation",
     subtitle: "Redesigning an accountant's critical monthly task.",
     slug: "/work/bank-rec",
-    status: "coming soon",
+    status: "in development",
     image1: BankRec_Explorer,
     image2: BankRec_Spire,
   },

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -64,6 +64,15 @@ export const CASE_STUDIES: Project[] = [
 
 export const DEV_PROJECTS: Project[] = [
   {
+    title: "AI Toolchain",
+    subtitle:
+      "A suite of Claude Code skills, agents, and MCP-driven workflows producing code-ready output. Adopted across teams for design system implementation and data migration.",
+    description: "",
+    slug: "/work/ai-tooling",
+    status: "in development",
+    tags: ["Claude Code", "MCP", "TypeScript", "Python"],
+  },
+  {
     title: "www.steamparty.io",
     subtitle:
       "When a couple of friends couldn't easily find which Steam games we all had in common, it was time for us to build the solution ourselves.",


### PR DESCRIPTION
Plumbing fixes:
- Fix "Reconcillation" typo on Bank Rec case study
- Fix `https://https://` SmartAdvocate link on homepage
- Fix resume PDF link case mismatch (was 404'ing on case-sensitive hosts)
- Replace duplicate copy-paste description on /work dylansmith.dev tile

Case study scaffolding:
- Add /work/design-system page with 5-section structure
  (Overview / Process / System / Contribution / Implementation)
- Add /work/ai-tooling page covering Claude Code skills + agents + MCP
- Add minimal /work/rapidpay page using existing legacy/spire images
- Add content/case-studies/*.md intake files mirroring page TODOs