### PR TITLE
fix(landing): atomic quote is first row in #intro bento, not hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -316,21 +316,6 @@ export default function Home() {
           id="hero"
           className="relative flex flex-col gap-6 px-6 py-12 text-slate-200 md:px-12 md:py-20 lg:py-24"
         >
-          <figure className="relative mx-auto w-full max-w-2xl rounded-md bg-slate-900/70 px-6 py-5 text-center font-mono text-sm text-slate-200 ring-1 ring-slate-700 backdrop-blur-sm md:px-10 md:py-6">
-            <Quote
-              aria-hidden="true"
-              className="absolute -top-5 left-1/2 h-10 w-10 -translate-x-1/2 rotate-180 fill-teal-300/20 text-teal-300/50"
-              strokeWidth={1.5}
-            />
-            <p className="text-base italic leading-relaxed text-slate-100 md:text-lg">
-              &ldquo;You don&apos;t rise to the level of your goals, you fall to
-              the level of your systems.&rdquo;
-            </p>
-            <figcaption className="mt-2 text-xs uppercase tracking-widest text-slate-400">
-              James Clear · Atomic Habits
-            </figcaption>
-          </figure>
-
           <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-4">
             <span className="text-5xl font-bold tracking-tight text-slate-100 lg:text-7xl">
               Dylan Smith
@@ -394,6 +379,29 @@ export default function Home() {
         >
           <VerticalText text="INTRO" />
           <div className="grid w-full auto-rows-[minmax(140px,auto)] grid-cols-1 gap-4 md:grid-cols-6 lg:grid-cols-12">
+            {/* 0 — ATOMIC HABITS QUOTE (first row, full-width) */}
+            <Tile
+              label="Atomic Habits"
+              labelIcon={Quote}
+              className="md:col-span-6 lg:col-span-12"
+              decorative
+            >
+              <div className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-4 text-center md:flex-row md:gap-8 md:py-6">
+                <Quote
+                  aria-hidden="true"
+                  className="h-10 w-10 shrink-0 rotate-180 fill-teal-300/20 text-teal-300/50 md:h-14 md:w-14"
+                  strokeWidth={1.5}
+                />
+                <p className="max-w-2xl font-mono text-base italic leading-relaxed text-slate-100 md:text-lg">
+                  &ldquo;You don&apos;t rise to the level of your goals, you
+                  fall to the level of your systems.&rdquo;
+                </p>
+                <span className="shrink-0 font-mono text-[10px] uppercase tracking-widest text-slate-400 md:text-xs">
+                  James Clear
+                </span>
+              </div>
+            </Tile>
+
             {/* 1 — DESIGN SYSTEMS (large, with inner mini-system demo) */}
             <Tile
               label="Design Systems shipped"


### PR DESCRIPTION
Correction to PR #24 — the quote was placed in the hero section but should live as the first full-width row of the #intro bento grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)