### PR TITLE
feat(hero): render resume button + socials below hero on mobile

### DIFF
--- a/src/components/CountUp.tsx
+++ b/src/components/CountUp.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  to: string;
+  duration?: number;
+  className?: string;
+};
+
+export function CountUp({ to, duration = 1500, className }: Props) {
+  const match = to.match(/^([\d,]+)(.*)$/);
+  const target = match ? parseInt(match[1].replace(/,/g, ""), 10) : 0;
+  const suffix = match ? match[2] : "";
+  const hasCommas = !!match && match[1].includes(",");
+
+  const ref = useRef<HTMLSpanElement>(null);
+  const [value, setValue] = useState(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !match) return;
+
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduce) {
+      setValue(target);
+      return;
+    }
+
+    let raf = 0;
+    const obs = new IntersectionObserver(
+      ([entry], o) => {
+        if (!entry.isIntersecting) return;
+        o.disconnect();
+        const start = performance.now();
+        const tick = (now: number) => {
+          const t = Math.min((now - start) / duration, 1);
+          const eased = 1 - Math.pow(1 - t, 3);
+          setValue(Math.round(target * eased));
+          if (t < 1) raf = requestAnimationFrame(tick);
+        };
+        raf = requestAnimationFrame(tick);
+      },
+      { threshold: 0.4 },
+    );
+    obs.observe(el);
+
+    return () => {
+      obs.disconnect();
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [target, duration, match]);
+
+  const display = hasCommas ? value.toLocaleString() : String(value);
+
+  return (
+    <span ref={ref} className={className}>
+      {match ? `${display}${suffix}` : to}
+    </span>
+  );
+}

--- a/src/components/CountUp.tsx
+++ b/src/components/CountUp.tsx
@@ -19,11 +19,14 @@ export function CountUp({ to, duration = 1500, className }: Props) {
 
   useEffect(() => {
     const el = ref.current;
-    if (!el || !match) return;
+    if (!el) return;
+    const m = to.match(/^([\d,]+)(.*)$/);
+    if (!m) return;
+    const tgt = parseInt(m[1].replace(/,/g, ""), 10);
 
     const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (reduce) {
-      setValue(target);
+      setValue(tgt);
       return;
     }
 
@@ -36,7 +39,7 @@ export function CountUp({ to, duration = 1500, className }: Props) {
         const tick = (now: number) => {
           const t = Math.min((now - start) / duration, 1);
           const eased = 1 - Math.pow(1 - t, 3);
-          setValue(Math.round(target * eased));
+          setValue(Math.round(tgt * eased));
           if (t < 1) raf = requestAnimationFrame(tick);
         };
         raf = requestAnimationFrame(tick);
@@ -49,7 +52,7 @@ export function CountUp({ to, duration = 1500, className }: Props) {
       obs.disconnect();
       if (raf) cancelAnimationFrame(raf);
     };
-  }, [target, duration, match]);
+  }, [to, duration]);
 
   const display = hasCommas ? value.toLocaleString() : String(value);
 

--- a/src/components/CountUp.tsx
+++ b/src/components/CountUp.tsx
@@ -58,7 +58,10 @@ export function CountUp({ to, duration = 1500, className }: Props) {
 
   return (
     <span ref={ref} className={className}>
-      {match ? `${display}${suffix}` : to}
+      <span aria-hidden="true">
+        {match ? `${display}${suffix}` : to}
+      </span>
+      <span className="sr-only">{to}</span>
     </span>
   );
 }

--- a/src/components/SectionLabel.tsx
+++ b/src/components/SectionLabel.tsx
@@ -11,12 +11,12 @@ export function SectionLabel({ as: Tag = "span", children, className }: Props) {
   return (
     <Tag
       className={cn(
-        "inline-flex items-center gap-3 font-mono text-sm uppercase tracking-widest text-slate-300",
+        "flex items-center gap-3 font-mono text-sm uppercase tracking-widest text-slate-300",
         className,
       )}
     >
-      <span aria-hidden="true" className="h-px w-8 bg-teal-300" />
       {children}
+      <span aria-hidden="true" className="h-px flex-1 bg-teal-300" />
     </Tag>
   );
 }

--- a/src/components/SectionLabel.tsx
+++ b/src/components/SectionLabel.tsx
@@ -16,7 +16,7 @@ export function SectionLabel({ as: Tag = "span", children, className }: Props) {
       )}
     >
       {children}
-      <span aria-hidden="true" className="h-px flex-1 bg-teal-300" />
+      <span aria-hidden="true" className="h-px flex-1 bg-purple-300" />
     </Tag>
   );
 }

--- a/src/components/SectionLabel.tsx
+++ b/src/components/SectionLabel.tsx
@@ -11,10 +11,11 @@ export function SectionLabel({ as: Tag = "span", children, className }: Props) {
   return (
     <Tag
       className={cn(
-        "font-mono text-sm uppercase tracking-widest text-slate-300",
+        "inline-flex items-center gap-3 font-mono text-sm uppercase tracking-widest text-slate-300",
         className,
       )}
     >
+      <span aria-hidden="true" className="h-px w-8 bg-teal-300" />
       {children}
     </Tag>
   );

--- a/src/components/SectionLabel.tsx
+++ b/src/components/SectionLabel.tsx
@@ -1,20 +1,21 @@
-import type { ReactNode } from "react";
+import type { ElementType, ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 type Props = {
+  as?: ElementType;
   children: ReactNode;
   className?: string;
 };
 
-export function SectionLabel({ children, className }: Props) {
+export function SectionLabel({ as: Tag = "span", children, className }: Props) {
   return (
-    <span
+    <Tag
       className={cn(
         "font-mono text-sm uppercase tracking-widest text-slate-300",
         className,
       )}
     >
       {children}
-    </span>
+    </Tag>
   );
 }

--- a/src/components/SectionLabel.tsx
+++ b/src/components/SectionLabel.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+type Props = {
+  children: ReactNode;
+  className?: string;
+};
+
+export function SectionLabel({ children, className }: Props) {
+  return (
+    <span
+      className={cn(
+        "font-mono text-sm uppercase tracking-widest text-slate-300",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/components/bento/BeforeAfterReveal.tsx
+++ b/src/components/bento/BeforeAfterReveal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode, useCallback, useRef, useState } from "react";
+import { ArrowLeftRight } from "lucide-react";
 import { Tag } from "@/components/Tag";
 
 type Props = {
@@ -52,8 +53,11 @@ function TapToggle({
       >
         {showAfter ? afterLabel : beforeLabel}
       </Tag>
-      <span className="pointer-events-none absolute bottom-2 right-2 z-20 rounded-full bg-slate-900/80 px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-teal-300 ring-1 ring-teal-300/40 backdrop-blur-sm">
-        Tap to swap
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute bottom-2 right-2 z-20 inline-flex h-10 w-10 items-center justify-center rounded-md bg-slate-800/60 text-slate-300 ring-1 ring-slate-700 backdrop-blur-sm"
+      >
+        <ArrowLeftRight className="h-[18px] w-[18px]" />
       </span>
     </button>
   );

--- a/src/components/bento/BeforeAfterReveal.tsx
+++ b/src/components/bento/BeforeAfterReveal.tsx
@@ -12,7 +12,54 @@ type Props = {
   initial?: number;
 };
 
-export function BeforeAfterReveal({
+export function BeforeAfterReveal(props: Props) {
+  const { className = "" } = props;
+  return (
+    <>
+      <TapToggle {...props} className={`md:hidden ${className}`} />
+      <DragReveal {...props} className={`hidden md:block ${className}`} />
+    </>
+  );
+}
+
+function TapToggle({
+  before,
+  after,
+  beforeLabel = "Before",
+  afterLabel = "After",
+  className = "",
+}: Props) {
+  const [showAfter, setShowAfter] = useState(true);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setShowAfter((v) => !v)}
+      aria-label={`Show ${showAfter ? beforeLabel : afterLabel}`}
+      className={`relative block w-full select-none overflow-hidden rounded-lg text-left ring-1 ring-slate-700 ${className}`}
+    >
+      <div className="relative">{after}</div>
+      <div
+        className="absolute inset-0 transition-opacity duration-500 ease-out motion-reduce:transition-none"
+        style={{ opacity: showAfter ? 0 : 1 }}
+        aria-hidden="true"
+      >
+        {before}
+      </div>
+      <Tag
+        intent={showAfter ? "teal" : "orange"}
+        className="pointer-events-none absolute left-2 top-2 z-20"
+      >
+        {showAfter ? afterLabel : beforeLabel}
+      </Tag>
+      <span className="pointer-events-none absolute bottom-2 right-2 z-20 rounded-full bg-slate-900/80 px-2 py-1 font-mono text-[10px] uppercase tracking-widest text-teal-300 ring-1 ring-teal-300/40 backdrop-blur-sm">
+        Tap to swap
+      </span>
+    </button>
+  );
+}
+
+function DragReveal({
   before,
   after,
   beforeLabel = "Before",

--- a/src/components/bento/BeforeAfterReveal.tsx
+++ b/src/components/bento/BeforeAfterReveal.tsx
@@ -37,7 +37,7 @@ function TapToggle({
       type="button"
       onClick={() => setShowAfter((v) => !v)}
       aria-label={`Show ${showAfter ? beforeLabel : afterLabel}`}
-      className={`relative block w-full select-none overflow-hidden rounded-lg text-left ring-1 ring-slate-700 ${className}`}
+      className={`relative block w-full select-none overflow-hidden rounded-lg text-left ring-1 ring-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${className}`}
     >
       <div className="relative">{after}</div>
       <div
@@ -155,7 +155,7 @@ function DragReveal({
         aria-valuemax={100}
         aria-valuenow={Math.round(pos)}
         onKeyDown={onKeyDown}
-        className={`absolute top-0 z-30 flex h-full w-1 cursor-ew-resize items-center justify-center bg-teal-300 focus:outline-none ${
+        className={`absolute top-0 z-30 flex h-full w-1 cursor-ew-resize items-center justify-center bg-teal-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 ${
           dragging ? "" : "motion-safe:transition-[left] motion-safe:duration-150"
         }`}
         style={{ left: `calc(${pos}% - 2px)` }}

--- a/src/components/bento/Feature.tsx
+++ b/src/components/bento/Feature.tsx
@@ -3,6 +3,7 @@
 import { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { Tag } from "@/components/Tag";
+import { CountUp } from "@/components/CountUp";
 
 type FeatureProps = {
   tags: string[];
@@ -46,9 +47,10 @@ export function Feature({
       >
         <div className="flex flex-col">
           <div className="flex items-baseline gap-3">
-            <span className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl">
-              {stat}
-            </span>
+            <CountUp
+              to={stat}
+              className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl"
+            />
             {statUnit && (
               <span className="font-sans text-lg font-medium leading-none text-slate-300 xl:text-xl 2xl:text-2xl">
                 {statUnit}

--- a/src/components/bento/Feature.tsx
+++ b/src/components/bento/Feature.tsx
@@ -16,7 +16,7 @@ type FeatureProps = {
 };
 
 const baseClasses =
-  "group relative flex flex-col gap-4 overflow-hidden rounded-2xl bg-slate-800/60 p-6 ring-1 ring-slate-700 backdrop-blur-sm transition-all duration-300 hover:ring-teal-300/60";
+  "group relative flex flex-col gap-4 overflow-hidden rounded-2xl bg-slate-900/80 p-6 ring-1 ring-slate-700 backdrop-blur-sm transition-all duration-300 hover:ring-teal-300/60";
 
 export function Feature({
   tags,

--- a/src/components/bento/Feature.tsx
+++ b/src/components/bento/Feature.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { Tag } from "@/components/Tag";
 import { CountUp } from "@/components/CountUp";
+import { Canvas, Ruler } from "@/components/canvas";
 
 type FeatureProps = {
   tags: string[];
@@ -13,6 +14,7 @@ type FeatureProps = {
   graphic?: ReactNode;
   graphicPosition?: "right" | "below";
   className?: string;
+  measured?: boolean;
 };
 
 const baseClasses =
@@ -26,11 +28,41 @@ export function Feature({
   graphic,
   graphicPosition = "right",
   className,
+  measured = false,
 }: FeatureProps) {
   const isBelow = graphicPosition === "below";
 
-  return (
-    <div className={cn(baseClasses, className)}>
+  const statRow = measured ? (
+    <Ruler className="flex w-fit items-baseline gap-3">
+      <Ruler.Guideline edge="top" />
+      <Ruler.Guideline edge="bottom" />
+      <Ruler.Target edge="right" />
+      <CountUp
+        to={stat}
+        className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl"
+      />
+      {statUnit && (
+        <span className="font-sans text-lg font-medium leading-none text-slate-300 xl:text-xl 2xl:text-2xl">
+          {statUnit}
+        </span>
+      )}
+    </Ruler>
+  ) : (
+    <div className="flex items-baseline gap-3">
+      <CountUp
+        to={stat}
+        className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl"
+      />
+      {statUnit && (
+        <span className="font-sans text-lg font-medium leading-none text-slate-300 xl:text-xl 2xl:text-2xl">
+          {statUnit}
+        </span>
+      )}
+    </div>
+  );
+
+  const body = (
+    <>
       <div className="hidden flex-wrap justify-end gap-1.5 text-slate-400 md:flex">
         {tags.map((t) => (
           <Tag key={t}>{t}</Tag>
@@ -46,17 +78,7 @@ export function Feature({
         )}
       >
         <div className="flex flex-col">
-          <div className="flex items-baseline gap-3">
-            <CountUp
-              to={stat}
-              className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl"
-            />
-            {statUnit && (
-              <span className="font-sans text-lg font-medium leading-none text-slate-300 xl:text-xl 2xl:text-2xl">
-                {statUnit}
-              </span>
-            )}
-          </div>
+          {statRow}
           <p className="mt-3 text-sm leading-relaxed text-slate-300">
             {subtitle}
           </p>
@@ -67,6 +89,11 @@ export function Feature({
           </div>
         )}
       </div>
-    </div>
+    </>
   );
+
+  if (measured) {
+    return <Canvas className={cn(baseClasses, className)}>{body}</Canvas>;
+  }
+  return <div className={cn(baseClasses, className)}>{body}</div>;
 }

--- a/src/components/bento/Feature.tsx
+++ b/src/components/bento/Feature.tsx
@@ -5,7 +5,6 @@ import { cn } from "@/lib/utils";
 import { Tag } from "@/components/Tag";
 
 type FeatureProps = {
-  verb: string;
   tags: string[];
   stat: string;
   statUnit?: string;
@@ -19,7 +18,6 @@ const baseClasses =
   "group relative flex flex-col gap-4 overflow-hidden rounded-2xl bg-slate-800/60 p-6 ring-1 ring-slate-700 backdrop-blur-sm transition-all duration-300 hover:ring-teal-300/60";
 
 export function Feature({
-  verb,
   tags,
   stat,
   statUnit,
@@ -32,15 +30,10 @@ export function Feature({
 
   return (
     <div className={cn(baseClasses, className)}>
-      <div className="flex items-start justify-between gap-4 text-slate-400">
-        <span className="font-mono text-xs uppercase tracking-widest">
-          {verb}
-        </span>
-        <div className="hidden flex-wrap items-start justify-end gap-1.5 md:flex">
-          {tags.map((t) => (
-            <Tag key={t}>{t}</Tag>
-          ))}
-        </div>
+      <div className="hidden flex-wrap justify-end gap-1.5 text-slate-400 md:flex">
+        {tags.map((t) => (
+          <Tag key={t}>{t}</Tag>
+        ))}
       </div>
 
       <div

--- a/src/components/bento/Feature.tsx
+++ b/src/components/bento/Feature.tsx
@@ -35,8 +35,8 @@ export function Feature({
   const statRow = measured ? (
     <Ruler className="flex w-fit items-baseline gap-3">
       <Ruler.Guideline edge="top" />
-      <Ruler.Guideline edge="bottom" />
-      <Ruler.Target edge="right" />
+      <Ruler.Guideline edge="right" />
+      <Ruler.Target edge="bottom" />
       <CountUp
         to={stat}
         className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl"

--- a/src/components/bento/Feature.tsx
+++ b/src/components/bento/Feature.tsx
@@ -36,7 +36,7 @@ export function Feature({
         <span className="font-mono text-xs uppercase tracking-widest">
           {verb}
         </span>
-        <div className="flex flex-wrap items-start justify-end gap-1.5">
+        <div className="hidden flex-wrap items-start justify-end gap-1.5 md:flex">
           {tags.map((t) => (
             <Tag key={t}>{t}</Tag>
           ))}

--- a/src/components/bento/Feature.tsx
+++ b/src/components/bento/Feature.tsx
@@ -4,7 +4,6 @@ import { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { Tag } from "@/components/Tag";
 import { CountUp } from "@/components/CountUp";
-import { Canvas, Ruler } from "@/components/canvas";
 
 type FeatureProps = {
   tags: string[];
@@ -14,7 +13,6 @@ type FeatureProps = {
   graphic?: ReactNode;
   graphicPosition?: "right" | "below";
   className?: string;
-  measured?: boolean;
 };
 
 const baseClasses =
@@ -28,41 +26,11 @@ export function Feature({
   graphic,
   graphicPosition = "right",
   className,
-  measured = false,
 }: FeatureProps) {
   const isBelow = graphicPosition === "below";
 
-  const statRow = measured ? (
-    <Ruler className="flex w-fit items-baseline gap-3">
-      <Ruler.Guideline edge="top" />
-      <Ruler.Guideline edge="right" />
-      <Ruler.Target edge="bottom" />
-      <CountUp
-        to={stat}
-        className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl"
-      />
-      {statUnit && (
-        <span className="font-sans text-lg font-medium leading-none text-slate-300 xl:text-xl 2xl:text-2xl">
-          {statUnit}
-        </span>
-      )}
-    </Ruler>
-  ) : (
-    <div className="flex items-baseline gap-3">
-      <CountUp
-        to={stat}
-        className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl"
-      />
-      {statUnit && (
-        <span className="font-sans text-lg font-medium leading-none text-slate-300 xl:text-xl 2xl:text-2xl">
-          {statUnit}
-        </span>
-      )}
-    </div>
-  );
-
-  const body = (
-    <>
+  return (
+    <div className={cn(baseClasses, className)}>
       <div className="hidden flex-wrap justify-end gap-1.5 text-slate-400 md:flex">
         {tags.map((t) => (
           <Tag key={t}>{t}</Tag>
@@ -78,7 +46,17 @@ export function Feature({
         )}
       >
         <div className="flex flex-col">
-          {statRow}
+          <div className="flex items-baseline gap-3">
+            <CountUp
+              to={stat}
+              className="font-sans text-4xl font-bold leading-none text-slate-100 xl:text-5xl 2xl:text-6xl"
+            />
+            {statUnit && (
+              <span className="font-sans text-lg font-medium leading-none text-slate-300 xl:text-xl 2xl:text-2xl">
+                {statUnit}
+              </span>
+            )}
+          </div>
           <p className="mt-3 text-sm leading-relaxed text-slate-300">
             {subtitle}
           </p>
@@ -89,11 +67,6 @@ export function Feature({
           </div>
         )}
       </div>
-    </>
+    </div>
   );
-
-  if (measured) {
-    return <Canvas className={cn(baseClasses, className)}>{body}</Canvas>;
-  }
-  return <div className={cn(baseClasses, className)}>{body}</div>;
 }

--- a/src/components/bento/StatTile.tsx
+++ b/src/components/bento/StatTile.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { ReactNode } from "react";
+import { LucideIcon } from "lucide-react";
 import { Tile } from "./Tile";
 import { CountUp } from "@/components/CountUp";
 
 type Props = {
+  icon?: LucideIcon;
   number: string;
   caption: string;
   className?: string;
@@ -13,6 +15,7 @@ type Props = {
 };
 
 export function StatTile({
+  icon: Icon,
   number,
   caption,
   className,
@@ -22,6 +25,13 @@ export function StatTile({
   const inner = (
     <>
       <div className="flex flex-1 flex-col justify-center">
+        {Icon && (
+          <Icon
+            aria-hidden="true"
+            className="mb-3 h-6 w-6 shrink-0 text-teal-300"
+            strokeWidth={1.5}
+          />
+        )}
         <CountUp
           to={number}
           className="font-sans text-3xl font-bold leading-none text-slate-100 xl:text-4xl 2xl:text-5xl"

--- a/src/components/bento/StatTile.tsx
+++ b/src/components/bento/StatTile.tsx
@@ -24,7 +24,7 @@ export function StatTile({
 }: Props) {
   const inner = (
     <>
-      <div className="flex flex-1 flex-col justify-center">
+      <div className="flex flex-1 flex-col">
         {Icon && (
           <Icon
             aria-hidden="true"

--- a/src/components/bento/StatTile.tsx
+++ b/src/components/bento/StatTile.tsx
@@ -1,12 +1,9 @@
 "use client";
 
 import { ReactNode } from "react";
-import { LucideIcon } from "lucide-react";
 import { Tile } from "./Tile";
 
 type Props = {
-  label: string;
-  labelIcon?: LucideIcon;
   number: string;
   caption: string;
   className?: string;
@@ -15,8 +12,6 @@ type Props = {
 };
 
 export function StatTile({
-  label,
-  labelIcon,
   number,
   caption,
   className,
@@ -39,18 +34,13 @@ export function StatTile({
 
   if (onClickModal) {
     return (
-      <Tile
-        label={label}
-        labelIcon={labelIcon}
-        className={className}
-        onClickModal={onClickModal}
-      >
+      <Tile className={className} onClickModal={onClickModal}>
         {inner}
       </Tile>
     );
   }
   return (
-    <Tile label={label} labelIcon={labelIcon} className={className} decorative>
+    <Tile className={className} decorative>
       {inner}
     </Tile>
   );

--- a/src/components/bento/StatTile.tsx
+++ b/src/components/bento/StatTile.tsx
@@ -2,6 +2,7 @@
 
 import { ReactNode } from "react";
 import { Tile } from "./Tile";
+import { CountUp } from "@/components/CountUp";
 
 type Props = {
   number: string;
@@ -21,9 +22,10 @@ export function StatTile({
   const inner = (
     <>
       <div className="flex flex-1 flex-col justify-center">
-        <span className="font-sans text-3xl font-bold leading-none text-slate-100 xl:text-4xl 2xl:text-5xl">
-          {number}
-        </span>
+        <CountUp
+          to={number}
+          className="font-sans text-3xl font-bold leading-none text-slate-100 xl:text-4xl 2xl:text-5xl"
+        />
         <p className="mt-3 max-w-[34ch] text-xs leading-snug text-slate-300 xl:text-sm 2xl:text-base">
           {caption}
         </p>

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -12,9 +12,9 @@ export function Hero() {
       id="hero"
       className="flex flex-col gap-8 px-6 py-12 text-slate-200 md:gap-10 md:px-12 md:py-20 lg:py-24"
     >
-      <span className="text-5xl font-bold tracking-tight text-slate-100 lg:text-7xl">
+      <h1 className="text-5xl font-bold tracking-tight text-slate-100 lg:text-7xl">
         Dylan Smith
-      </span>
+      </h1>
 
       <div className="max-w-3xl text-lg font-medium leading-loose text-slate-200 lg:text-2xl">
         Designing &amp; developing{" "}

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -12,13 +12,9 @@ export function Hero() {
       id="hero"
       className="flex flex-col gap-8 px-6 py-12 text-slate-200 md:gap-10 md:px-12 md:py-20 lg:py-24"
     >
-      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-4">
-        <span className="text-5xl font-bold tracking-tight text-slate-100 lg:text-7xl">
-          Dylan Smith
-        </span>
-        <div className="flex flex-wrap items-center gap-3">
-        </div>
-      </div>
+      <span className="text-5xl font-bold tracking-tight text-slate-100 lg:text-7xl">
+        Dylan Smith
+      </span>
 
       <div className="max-w-3xl text-lg font-medium leading-loose text-slate-200 lg:text-2xl">
         Designing &amp; developing{" "}
@@ -48,6 +44,20 @@ export function Hero() {
             className="absolute inset-x-0 -bottom-0.5 top-0 z-10 w-0 bg-teal-300 transition-all duration-500 ease-in-out group-hover:w-full"
           />
         </a>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 lg:hidden">
+        <Button
+          href="/Dylan-Smith-Resume.pdf"
+          target="_blank"
+          rel="noreferrer"
+          variant="primary"
+        >
+          <FileText aria-hidden="true" />
+          Resume
+        </Button>
+        <SocialLink site="github" />
+        <SocialLink site="linkedin" />
       </div>
     </Canvas>
   );

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -134,8 +134,7 @@ function Principles() {
               </h3>
             </div>
             <p className="text-sm leading-relaxed text-slate-300">
-              Today&apos;s shortcut is tomorrow&apos;s debt. Document the why,
-              name things twice, leave clear breadcrumbs.
+              Document the why and leave clever breadcrumbs.
             </p>
           </div>
         </div>

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -5,7 +5,7 @@ import {
   Quote,
   Search,
   Puzzle,
-  Wrench,
+  HeartHandshake,
   Boxes,
   Workflow,
   Sparkles,
@@ -88,46 +88,53 @@ function Principles() {
         </span>
         <div className="mt-6 grid grid-cols-1 gap-8 md:grid-cols-3">
           <div className="flex flex-col gap-3">
-            <Search
-              aria-hidden="true"
-              className="h-6 w-6 shrink-0 text-teal-300"
-              strokeWidth={1.5}
-            />
-            <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-              Details Matter
-            </h3>
+            <div className="flex items-center gap-3 md:contents">
+              <Search
+                aria-hidden="true"
+                className="h-6 w-6 shrink-0 text-teal-300"
+                strokeWidth={1.5}
+              />
+              <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
+                Details Matter
+              </h3>
+            </div>
             <p className="text-sm leading-relaxed text-slate-300">
-              Pixel-perfect isn&apos;t a slogan. Token-level spec,
-              state-by-state docs, schemas worth shipping from.
+              Small details compound over large surfaces to make a big
+              difference.
             </p>
           </div>
 
           <div className="flex flex-col gap-3">
-            <Puzzle
-              aria-hidden="true"
-              className="h-6 w-6 shrink-0 text-teal-300"
-              strokeWidth={1.5}
-            />
-            <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-              Solutions First
-            </h3>
+            <div className="flex items-center gap-3 md:contents">
+              <Puzzle
+                aria-hidden="true"
+                className="h-6 w-6 shrink-0 text-teal-300"
+                strokeWidth={1.5}
+              />
+              <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
+                Solutions First
+              </h3>
+            </div>
             <p className="text-sm leading-relaxed text-slate-300">
-              Solve the problem before naming the system. Systems emerge from
-              solutions, not the other way around.
+              Work backwards from the blue-sky result. Systems support the
+              solution, not the other way around.
             </p>
           </div>
 
           <div className="flex flex-col gap-3">
-            <Wrench
-              aria-hidden="true"
-              className="h-6 w-6 shrink-0 text-teal-300"
-              strokeWidth={1.5}
-            />
-            <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-              Tools, Not Masters
-            </h3>
+            <div className="flex items-center gap-3 md:contents">
+              <HeartHandshake
+                aria-hidden="true"
+                className="h-6 w-6 shrink-0 text-teal-300"
+                strokeWidth={1.5}
+              />
+              <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
+                Be nice to your future self
+              </h3>
+            </div>
             <p className="text-sm leading-relaxed text-slate-300">
-              My tools exist to serve me, not the other way around.
+              Today&apos;s shortcut is tomorrow&apos;s debt. Document the why,
+              name things twice, leave clear breadcrumbs.
             </p>
           </div>
         </div>

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -13,6 +13,7 @@ import {
 import VerticalText from "@/components/VerticalText";
 import { TechLogo } from "@/components/TechLogo";
 import { Tag } from "@/components/Tag";
+import { SectionLabel } from "@/components/SectionLabel";
 
 type IntroProps = {
   sectionRef: RefObject<HTMLDivElement>;
@@ -84,9 +85,7 @@ function Principles() {
 
       {/* First Principles grid */}
       <div className="mt-12 md:mt-16">
-        <span className="font-mono text-xs uppercase tracking-widest text-slate-400">
-          First Principles
-        </span>
+        <SectionLabel>First Principles</SectionLabel>
         <div className="mt-6 grid grid-cols-1 gap-8 md:grid-cols-3">
           <div className="flex flex-col gap-3">
             <div className="flex items-center gap-3 md:contents">
@@ -146,9 +145,7 @@ function Principles() {
 function Tools() {
   return (
     <div>
-      <span className="font-mono text-xs uppercase tracking-widest text-slate-400">
-        Tools &amp; Languages
-      </span>
+      <SectionLabel>Tools &amp; Languages</SectionLabel>
       <div className="mt-6 flex flex-col gap-6">
         <div className="flex flex-wrap items-center gap-x-7 gap-y-5 text-slate-300">
           {TOOLS.map((t) => (
@@ -180,9 +177,7 @@ function Tools() {
 function Practices() {
   return (
     <div>
-      <span className="font-mono text-xs uppercase tracking-widest text-slate-400">
-        Practices
-      </span>
+      <SectionLabel>Practices</SectionLabel>
       <div className="mt-6 grid grid-cols-1 gap-8 md:grid-cols-3">
         <div className="flex flex-col gap-3">
           <Boxes

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -95,7 +95,7 @@ function Principles() {
                 strokeWidth={1.5}
               />
               <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-                Details Matter
+                The details matter
               </h3>
             </div>
             <p className="text-sm leading-relaxed text-slate-300">
@@ -112,7 +112,7 @@ function Principles() {
                 strokeWidth={1.5}
               />
               <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-                Solutions First
+                Solutions first
               </h3>
             </div>
             <p className="text-sm leading-relaxed text-slate-300">

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -65,8 +65,9 @@ export function Intro({ sectionRef }: IntroProps) {
 
 function Principles() {
   return (
-    <div>
-      {/* Pull-quote callout */}
+    <div className="flex flex-col gap-6">
+      <SectionLabel>First Principles</SectionLabel>
+
       <blockquote className="flex flex-col gap-4 rounded-xl bg-slate-800/40 p-6 ring-1 ring-slate-700 backdrop-blur-sm md:flex-row md:items-start md:gap-6">
         <Quote
           aria-hidden="true"
@@ -84,65 +85,61 @@ function Principles() {
         </div>
       </blockquote>
 
-      {/* First Principles grid */}
-      <div className="mt-12 md:mt-16">
-        <SectionLabel>First Principles</SectionLabel>
-        <div className="mt-6 grid grid-cols-1 gap-8 md:grid-cols-3">
-          <Canvas className="flex flex-col gap-3">
-            <div className="flex items-center gap-3 md:contents">
-              <Search
-                aria-hidden="true"
-                className="h-6 w-6 shrink-0 text-teal-300"
-                strokeWidth={1.5}
-              />
-              <Ruler
-                as="h3"
-                className="w-fit font-serif text-xl font-semibold text-slate-100 lg:text-2xl"
-              >
-                <Ruler.Guideline edge="top" />
-                <Ruler.Guideline edge="bottom" />
-                <Ruler.Target edge="right" />
-                The details matter
-              </Ruler>
-            </div>
-            <p className="text-sm leading-relaxed text-slate-300">
-              Small details compound over large surfaces to make a big
-              difference.
-            </p>
-          </Canvas>
-
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-3 md:contents">
-              <Puzzle
-                aria-hidden="true"
-                className="h-6 w-6 shrink-0 text-teal-300"
-                strokeWidth={1.5}
-              />
-              <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-                Solutions over tools
-              </h3>
-            </div>
-            <p className="text-sm leading-relaxed text-slate-300">
-              Work backwards from the blue-sky result. Systems support the
-              solution, not the other way around.
-            </p>
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+        <Canvas className="flex flex-col gap-3">
+          <div className="flex items-center gap-3 md:contents">
+            <Search
+              aria-hidden="true"
+              className="h-6 w-6 shrink-0 text-teal-300"
+              strokeWidth={1.5}
+            />
+            <Ruler
+              as="h3"
+              className="w-fit font-serif text-xl font-semibold text-slate-100 lg:text-2xl"
+            >
+              <Ruler.Guideline edge="top" />
+              <Ruler.Guideline edge="bottom" />
+              <Ruler.Target edge="right" />
+              The details matter
+            </Ruler>
           </div>
+          <p className="text-sm leading-relaxed text-slate-300">
+            Small details compound over large surfaces to make a big
+            difference.
+          </p>
+        </Canvas>
 
-          <div className="flex flex-col gap-3">
-            <div className="flex items-center gap-3 md:contents">
-              <HeartHandshake
-                aria-hidden="true"
-                className="h-6 w-6 shrink-0 text-teal-300"
-                strokeWidth={1.5}
-              />
-              <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-                Be kind to your future self
-              </h3>
-            </div>
-            <p className="text-sm leading-relaxed text-slate-300">
-              Document the why and leave clever breadcrumbs.
-            </p>
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3 md:contents">
+            <Puzzle
+              aria-hidden="true"
+              className="h-6 w-6 shrink-0 text-teal-300"
+              strokeWidth={1.5}
+            />
+            <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
+              Solutions over tools
+            </h3>
           </div>
+          <p className="text-sm leading-relaxed text-slate-300">
+            Work backwards from the blue-sky result. Systems support the
+            solution, not the other way around.
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center gap-3 md:contents">
+            <HeartHandshake
+              aria-hidden="true"
+              className="h-6 w-6 shrink-0 text-teal-300"
+              strokeWidth={1.5}
+            />
+            <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
+              Be kind to your future self
+            </h3>
+          </div>
+          <p className="text-sm leading-relaxed text-slate-300">
+            Document the why and leave clever breadcrumbs.
+          </p>
         </div>
       </div>
     </div>
@@ -151,31 +148,28 @@ function Principles() {
 
 function Tools() {
   return (
-    <div>
-      <SectionLabel>Tools &amp; Languages</SectionLabel>
-      <div className="mt-6 flex flex-col gap-6">
-        <div className="flex flex-wrap items-center gap-x-7 gap-y-5 text-slate-300">
-          {TOOLS.map((t) => (
-            <TechLogo
-              key={t.name}
-              name={t.name}
-              label={t.label}
-              brandColor={t.brandColor}
-              size={36}
-            />
-          ))}
-        </div>
-        <div className="flex flex-wrap items-center gap-3">
-          {TAGS.map((t) => (
-            <Tag
-              key={t}
-              size="md"
-              className="transition-colors hover:text-slate-100 hover:ring-slate-500"
-            >
-              {t}
-            </Tag>
-          ))}
-        </div>
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-center gap-x-7 gap-y-5 text-slate-300">
+        {TOOLS.map((t) => (
+          <TechLogo
+            key={t.name}
+            name={t.name}
+            label={t.label}
+            brandColor={t.brandColor}
+            size={36}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        {TAGS.map((t) => (
+          <Tag
+            key={t}
+            size="md"
+            className="transition-colors hover:text-slate-100 hover:ring-slate-500"
+          >
+            {t}
+          </Tag>
+        ))}
       </div>
     </div>
   );

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -14,6 +14,7 @@ import VerticalText from "@/components/VerticalText";
 import { TechLogo } from "@/components/TechLogo";
 import { Tag } from "@/components/Tag";
 import { SectionLabel } from "@/components/SectionLabel";
+import { Canvas, Ruler } from "@/components/canvas";
 
 type IntroProps = {
   sectionRef: RefObject<HTMLDivElement>;
@@ -87,22 +88,28 @@ function Principles() {
       <div className="mt-12 md:mt-16">
         <SectionLabel>First Principles</SectionLabel>
         <div className="mt-6 grid grid-cols-1 gap-8 md:grid-cols-3">
-          <div className="flex flex-col gap-3">
+          <Canvas className="flex flex-col gap-3">
             <div className="flex items-center gap-3 md:contents">
               <Search
                 aria-hidden="true"
                 className="h-6 w-6 shrink-0 text-teal-300"
                 strokeWidth={1.5}
               />
-              <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
+              <Ruler
+                as="h3"
+                className="w-fit font-serif text-xl font-semibold text-slate-100 lg:text-2xl"
+              >
+                <Ruler.Guideline edge="top" />
+                <Ruler.Guideline edge="bottom" />
+                <Ruler.Target edge="right" />
                 The details matter
-              </h3>
+              </Ruler>
             </div>
             <p className="text-sm leading-relaxed text-slate-300">
               Small details compound over large surfaces to make a big
               difference.
             </p>
-          </div>
+          </Canvas>
 
           <div className="flex flex-col gap-3">
             <div className="flex items-center gap-3 md:contents">

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -129,7 +129,7 @@ function Principles() {
                 strokeWidth={1.5}
               />
               <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-                Be nice to your future self
+                Be kind to your future self
               </h3>
             </div>
             <p className="text-sm leading-relaxed text-slate-300">

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -51,6 +51,7 @@ export function Intro({ sectionRef }: IntroProps) {
       className="relative flex flex-col px-6 pb-12 pt-16 md:px-12 md:pt-24 lg:flex-row lg:gap-6 lg:pt-16"
     >
       <VerticalText text="INTRO" />
+      <h2 className="sr-only">Intro</h2>
       <div className="flex w-full flex-col gap-10 md:gap-14">
         <Principles />
         <Tools />

--- a/src/components/landing/Intro.tsx
+++ b/src/components/landing/Intro.tsx
@@ -112,7 +112,7 @@ function Principles() {
                 strokeWidth={1.5}
               />
               <h3 className="font-serif text-xl font-semibold text-slate-100 lg:text-2xl">
-                Solutions first
+                Solutions over tools
               </h3>
             </div>
             <p className="text-sm leading-relaxed text-slate-300">

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -27,6 +27,7 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
           tags={["Tokens", "Atomic", "WCAG"]}
           stat="2"
           statUnit="design systems shipped"
+          measured
           subtitle={
             <>
               First-of-their-kind at MDS and{" "}

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -51,14 +51,14 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
           icon={FileText}
           number="100+"
           caption="pages of documentation contributed — patterns, conventions, schemas — the docs the engineering team ships from."
-          className="md:col-span-3 lg:col-span-4"
+          className="self-start md:col-span-3 lg:col-span-4"
         />
 
         <StatTile
           icon={Briefcase}
           number="10+ yrs"
           caption="across design, development, data engineering, and support — the full software lifecycle."
-          className="md:col-span-3 lg:col-span-4"
+          className="self-start md:col-span-3 lg:col-span-4"
         />
 
         <Feature

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -51,14 +51,14 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
           icon={FileText}
           number="100+"
           caption="pages of documentation contributed — patterns, conventions, schemas — the docs the engineering team ships from."
-          className="self-start md:col-span-3 lg:col-span-4"
+          className="md:col-span-3 lg:col-span-4"
         />
 
         <StatTile
           icon={Briefcase}
           number="10+ yrs"
           caption="across design, development, data engineering, and support — the full software lifecycle."
-          className="self-start md:col-span-3 lg:col-span-4"
+          className="md:col-span-3 lg:col-span-4"
         />
 
         <Feature

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { RefObject } from "react";
+import { Briefcase, FileText } from "lucide-react";
 import VerticalText from "@/components/VerticalText";
 import { SectionLabel } from "@/components/SectionLabel";
 import { StatTile } from "@/components/bento/StatTile";
@@ -47,12 +48,14 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
         />
 
         <StatTile
+          icon={FileText}
           number="100+"
           caption="pages of documentation contributed — patterns, conventions, schemas — the docs the engineering team ships from."
           className="md:col-span-3 lg:col-span-4"
         />
 
         <StatTile
+          icon={Briefcase}
           number="10+ yrs"
           caption="across design, development, data engineering, and support — the full software lifecycle."
           className="md:col-span-3 lg:col-span-4"

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { RefObject } from "react";
-import { Briefcase, FileText, Layers } from "lucide-react";
 import VerticalText from "@/components/VerticalText";
 import { StatTile } from "@/components/bento/StatTile";
 import { Feature } from "@/components/bento/Feature";
@@ -22,7 +21,6 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
       <VerticalText text="outcomes" />
       <div className="grid w-full auto-rows-[minmax(140px,auto)] grid-cols-2 gap-4 md:grid-cols-6 lg:grid-cols-12">
         <Feature
-          verb="Designed & Developed"
           tags={["Tokens", "Atomic", "WCAG"]}
           stat="2"
           statUnit="design systems shipped"
@@ -46,23 +44,18 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
         />
 
         <StatTile
-          label="Docs Contributor"
-          labelIcon={FileText}
           number="100+"
           caption="pages of documentation contributed — patterns, conventions, schemas — the docs the engineering team ships from."
           className="md:col-span-3 lg:col-span-4"
         />
 
         <StatTile
-          label="In the industry"
-          labelIcon={Briefcase}
           number="10+ yrs"
           caption="across design, development, data engineering, and support — the full software lifecycle."
           className="md:col-span-3 lg:col-span-4"
         />
 
         <Feature
-          verb="Faster data migrations"
           tags={["Python", "Monorepo", "CI/CD"]}
           stat="60%"
           statUnit="faster data migrations"

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -20,7 +20,7 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
       className="relative flex flex-col px-6 pb-12 pt-16 md:px-12 md:pt-24 lg:flex-row lg:gap-6 lg:pt-16"
     >
       <VerticalText text="outcomes" />
-      <div className="grid w-full auto-rows-[minmax(140px,auto)] grid-cols-1 gap-4 md:grid-cols-6 lg:grid-cols-12">
+      <div className="grid w-full auto-rows-[minmax(140px,auto)] grid-cols-2 gap-4 md:grid-cols-6 lg:grid-cols-12">
         <Feature
           verb="Designed & Developed"
           tags={["Tokens", "Atomic", "WCAG"]}
@@ -42,7 +42,7 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
           }
           graphic={<MiniSystemDemo />}
           graphicPosition="below"
-          className="md:col-span-6 lg:col-span-8 lg:row-span-2"
+          className="col-span-2 md:col-span-6 lg:col-span-8 lg:row-span-2"
         />
 
         <StatTile
@@ -79,7 +79,7 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
           }
           graphic={<ScriptsToToolkit />}
           graphicPosition="below"
-          className="md:col-span-6 lg:col-span-12"
+          className="col-span-2 md:col-span-6 lg:col-span-12"
         />
 
         {/* <StatTile

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -2,6 +2,7 @@
 
 import type { RefObject } from "react";
 import VerticalText from "@/components/VerticalText";
+import { SectionLabel } from "@/components/SectionLabel";
 import { StatTile } from "@/components/bento/StatTile";
 import { Feature } from "@/components/bento/Feature";
 import { MiniSystemDemo } from "./visuals/MiniSystemDemo";
@@ -19,8 +20,9 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
       className="relative flex flex-col px-6 pb-12 pt-16 md:px-12 md:pt-24 lg:flex-row lg:gap-6 lg:pt-16"
     >
       <VerticalText text="outcomes" />
-      <h2 className="sr-only">Outcomes</h2>
-      <div className="grid w-full auto-rows-[minmax(140px,auto)] grid-cols-2 gap-4 md:grid-cols-6 lg:grid-cols-12">
+      <div className="flex w-full flex-col gap-6">
+        <SectionLabel as="h2">Outcomes</SectionLabel>
+        <div className="grid w-full auto-rows-[minmax(140px,auto)] grid-cols-2 gap-4 md:grid-cols-6 lg:grid-cols-12">
         <Feature
           tags={["Tokens", "Atomic", "WCAG"]}
           stat="2"
@@ -83,6 +85,7 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
           caption="Daily users on keystone features I led from concept to production at MDS."
           className="md:col-span-3 lg:col-span-6"
         /> */}
+        </div>
       </div>
     </section>
   );

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -27,7 +27,6 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
           tags={["Tokens", "Atomic", "WCAG"]}
           stat="2"
           statUnit="design systems shipped"
-          measured
           subtitle={
             <>
               First-of-their-kind at MDS and{" "}

--- a/src/components/landing/Outcomes.tsx
+++ b/src/components/landing/Outcomes.tsx
@@ -19,6 +19,7 @@ export function Outcomes({ sectionRef }: OutcomesProps) {
       className="relative flex flex-col px-6 pb-12 pt-16 md:px-12 md:pt-24 lg:flex-row lg:gap-6 lg:pt-16"
     >
       <VerticalText text="outcomes" />
+      <h2 className="sr-only">Outcomes</h2>
       <div className="grid w-full auto-rows-[minmax(140px,auto)] grid-cols-2 gap-4 md:grid-cols-6 lg:grid-cols-12">
         <Feature
           tags={["Tokens", "Atomic", "WCAG"]}

--- a/src/components/landing/Work.tsx
+++ b/src/components/landing/Work.tsx
@@ -4,6 +4,7 @@ import type { RefObject } from "react";
 import Image from "next/image";
 import { ArrowUpRight, CreditCard, Layers } from "lucide-react";
 import VerticalText from "@/components/VerticalText";
+import { SectionLabel } from "@/components/SectionLabel";
 import { TagGroup } from "@/components/Tag";
 import { Tile } from "@/components/bento/Tile";
 import { BeforeAfterReveal } from "@/components/bento/BeforeAfterReveal";
@@ -36,8 +37,8 @@ export function Work({ sectionRef }: WorkProps) {
       className="relative flex flex-col px-6 pb-24 md:px-12 lg:flex-row lg:gap-6 lg:pt-32"
     >
       <VerticalText text="WORK" />
-      <h2 className="sr-only">Work</h2>
       <div className="flex w-full flex-col gap-4">
+        <SectionLabel as="h2">Work</SectionLabel>
         {/* TODO(smartadvocate): drop legacy.png + spire.png into
             public/case-studies/smartadvocate/, uncomment the imports above,
             and uncomment this <Tile>. */}

--- a/src/components/landing/Work.tsx
+++ b/src/components/landing/Work.tsx
@@ -36,6 +36,7 @@ export function Work({ sectionRef }: WorkProps) {
       className="relative flex flex-col px-6 pb-24 md:px-12 lg:flex-row lg:gap-6 lg:pt-32"
     >
       <VerticalText text="WORK" />
+      <h2 className="sr-only">Work</h2>
       <div className="flex w-full flex-col gap-4">
         {/* TODO(smartadvocate): drop legacy.png + spire.png into
             public/case-studies/smartadvocate/, uncomment the imports above,

--- a/src/components/landing/visuals/MiniSystemDemo.tsx
+++ b/src/components/landing/visuals/MiniSystemDemo.tsx
@@ -5,7 +5,7 @@ import { StateChips } from "@/components/bento/StateChips";
 
 export function MiniSystemDemo() {
   return (
-    <div className="mt-4 flex flex-col gap-3 rounded-lg bg-slate-900/70 p-4 ring-1 ring-slate-700 backdrop-blur-sm">
+    <div className="mt-4 flex flex-col gap-3">
       <div>
         <span className="font-mono text-[9px] uppercase tracking-widest text-slate-500">
           Tokens

--- a/src/components/landing/visuals/ScriptsToToolkit.tsx
+++ b/src/components/landing/visuals/ScriptsToToolkit.tsx
@@ -6,7 +6,7 @@ import { ScatteredFiles } from "./ScatteredFiles";
 
 export function ScriptsToToolkit() {
   return (
-    <div className="flex flex-col items-stretch gap-4 rounded-lg bg-slate-900/80 p-6 ring-1 ring-slate-700 lg:flex-row lg:items-center lg:justify-between lg:gap-8">
+    <div className="flex flex-col items-stretch gap-4 lg:flex-row lg:items-center lg:justify-between lg:gap-8">
       <ScatteredFiles />
 
       <ArrowRight


### PR DESCRIPTION
The Header sidebar holding these controls is hidden until the lg
breakpoint, leaving mobile/tablet without a visible path to the
resume or social links. Add a matching cluster inside Hero, scoped
to lg:hidden so the desktop sidebar remains the single source on
large screens.

https://claude.ai/code/session_01UcRQgGScp3nhUBaE1fGtS4